### PR TITLE
Ensure thread safe IPC handlers on iOS

### DIFF
--- a/shared/apple/ipc.h
+++ b/shared/apple/ipc.h
@@ -5,8 +5,10 @@
 extern "C" {
 #endif
 
-#include <dispatch/dispatch.h>
+#include <stdatomic.h>
 #include <stdbool.h>
+
+#include <dispatch/dispatch.h>
 
 #include "../ipc.h"
 
@@ -19,7 +21,7 @@ struct bare_ipc_poll_s {
 
   int events;
 
-  bare_ipc_poll_cb cb;
+  _Atomic bare_ipc_poll_cb cb;
 
   void *data;
 };


### PR DESCRIPTION
1. Blocks always execute on a separate thread.
2. Access to the poll callback is synchronised with a lockfree atomic.
3. When closing IPC, outstanding blocks are flushed before returning.

As a result, neither `bare_ipc_poll_stop()` nor `bare_ipc_poll_destroy()` should ever bork an executing block.