### PR TITLE
Export newly added symbols on windows

### DIFF
--- a/win32/worklet.def
+++ b/win32/worklet.def
@@ -3,6 +3,12 @@ EXPORTS
   bare_worklet_alloc
   bare_worklet_init
   bare_worklet_destroy
+  bare_worklet_on_suspend
+  bare_worklet_on_wakeup
+  bare_worklet_on_idle
+  bare_worklet_on_resume
+  bare_worklet_on_thread_enter
+  bare_worklet_on_thread_exit
   bare_worklet_get_data
   bare_worklet_set_data
   bare_worklet_start


### PR DESCRIPTION
The new `bare_worklet_on_*` hooks are not exported on windows. Export them so they can be used.