### PR TITLE
Ship Linux prebuilds in the release

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -150,4 +150,6 @@ jobs:
             prebuilds/ios/BareKit.xcframework
             prebuilds/ios-javascriptcore/BareKit.xcframework
             prebuilds/android/bare-kit
+            prebuilds/linux/x64/libbare-kit.so
+            prebuilds/linux/arm64/libbare-kit.so
           retention-days: 5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -152,6 +152,8 @@ jobs:
             prebuilds/ios/BareKit.xcframework
             prebuilds/ios-javascriptcore/BareKit.xcframework
             prebuilds/android/bare-kit
+            prebuilds/linux/x64/libbare-kit.so
+            prebuilds/linux/arm64/libbare-kit.so
           retention-days: 5
   publish:
     runs-on: ubuntu-latest

--- a/prebuilds/Makefile
+++ b/prebuilds/Makefile
@@ -23,7 +23,9 @@ all: \
 	darwin-javascriptcore/BareKit.xcframework \
 	ios/BareKit.xcframework \
 	ios-javascriptcore/BareKit.xcframework \
-	android/bare-kit
+	android/bare-kit \
+	linux/x64/libbare-kit.so \
+	linux/arm64/libbare-kit.so
 
 apple/BareKit.xcframework: \
 	darwin/BareKit.framework \
@@ -70,3 +72,7 @@ ios-javascriptcore/BareKit.framework: \
 ios-simulator-javascriptcore/BareKit.framework: \
 	ios-arm64-simulator-javascriptcore/BareKit.framework \
 	ios-x64-simulator-javascriptcore/BareKit.framework
+
+linux/%/libbare-kit.so: linux-%/libbare-kit.so
+	mkdir -p $(dir $@)
+	cp -a $< $@


### PR DESCRIPTION
Draft / RFC - opening this to get your view before going further.

The `linux` job already builds `build/linux/*.so`, but it is never packaged: the prebuilds Makefile and the merge/publish upload lists only cover apple/ios/android, so the `.so` is thrown away. This adds the Linux slice to `prebuilds.zip` as `linux/<arch>/libbare-kit.so`.

What this does not solve: a `.so` alone is not compilable - `worklet.h` pulls in `bare.h`/`js.h`/`uv.h`, so a C consumer still needs those headers. I think the public C header should be self-contained. Two ways to get there:

- **A (non-breaking, minor):** opaque worklet handle + move the 4 lifecycle hooks into an opt-in `worklet/lifecycle.h`. Core `worklet.h` then needs only `uv.h`. RN is unaffected (it vendors its own decls).
- **B (breaking, major):** also drop `uv_buf_t` from the API so it needs nothing external. Requires an RN update.

Questions for you:
- OK to ship the Linux slice this way? Layout `linux/<arch>/libbare-kit.so`, or would you prefer `linux-<arch>/` to match the artifact names?
- Header cleanup: A now and B later, or both in one major?
- Worth splitting `prebuilds.zip` into a per-platform asset (e.g. `linux.zip`, `darwin.zip`, ...)? Right now a consumer downloads every platform just to extract one slice; a separate asset per platform would cut the download a lot (the darwin framework alone is ~135 MB), and it only gets worse as we add platforms.
