### PR TITLE
move android thread enter/exit

### DIFF
--- a/android/src/main/jni/Worklet.c
+++ b/android/src/main/jni/Worklet.c
@@ -2,6 +2,7 @@
 #include <jni.h>
 #include <stdlib.h>
 
+#include "../../../../shared/android/worklet.h"
 #include "../../../../shared/worklet.h"
 
 typedef struct {
@@ -37,6 +38,13 @@ Java_to_holepunch_bare_kit_Worklet_init(JNIEnv *env, jobject self, jint jmemory_
   }
 
   err = bare_worklet_init(&context->worklet, &options);
+  assert(err == 0);
+
+  JavaVM *vm;
+  err = (*env)->GetJavaVM(env, &vm);
+  assert(err == JNI_OK);
+
+  err = bare_worklet_android_attach_vm(&context->worklet, vm);
   assert(err == 0);
 
   if (options.assets) {

--- a/android/src/main/jni/Worklet.c
+++ b/android/src/main/jni/Worklet.c
@@ -6,8 +6,6 @@
 
 typedef struct {
   bare_worklet_t worklet;
-
-  JavaVM *vm;
 } bare_worklet_context_t;
 
 typedef struct {
@@ -20,86 +18,6 @@ typedef struct {
   jobject callback;
 } bare_worklet_push_context_t;
 
-static void
-bare_worklet_set_context_class_loader(JNIEnv *env) {
-  jclass thread_class = (*env)->FindClass(env, "java/lang/Thread");
-  assert(thread_class != NULL);
-
-  jmethodID current_thread = (*env)->GetStaticMethodID(env, thread_class, "currentThread", "()Ljava/lang/Thread;");
-  assert(current_thread != NULL);
-
-  jobject thread = (*env)->CallStaticObjectMethod(env, thread_class, current_thread);
-  assert(thread != NULL);
-  assert(!(*env)->ExceptionCheck(env));
-
-  jclass activity_thread_class = (*env)->FindClass(env, "android/app/ActivityThread");
-  assert(activity_thread_class != NULL);
-
-  jmethodID current_application = (*env)->GetStaticMethodID(env, activity_thread_class, "currentApplication", "()Landroid/app/Application;");
-  assert(current_application != NULL);
-
-  jobject application = (*env)->CallStaticObjectMethod(env, activity_thread_class, current_application);
-  assert(application != NULL);
-  assert(!(*env)->ExceptionCheck(env));
-
-  jclass application_class = (*env)->GetObjectClass(env, application);
-  assert(application_class != NULL);
-
-  jmethodID get_class_loader = (*env)->GetMethodID(env, application_class, "getClassLoader", "()Ljava/lang/ClassLoader;");
-  assert(get_class_loader != NULL);
-
-  jobject class_loader = (*env)->CallObjectMethod(env, application, get_class_loader);
-  assert(class_loader != NULL);
-  assert(!(*env)->ExceptionCheck(env));
-
-  jmethodID set_context_class_loader = (*env)->GetMethodID(env, thread_class, "setContextClassLoader", "(Ljava/lang/ClassLoader;)V");
-  assert(set_context_class_loader != NULL);
-
-  (*env)->CallVoidMethod(env, thread, set_context_class_loader, class_loader);
-  assert(!(*env)->ExceptionCheck(env));
-
-  (*env)->DeleteLocalRef(env, class_loader);
-  (*env)->DeleteLocalRef(env, application_class);
-  (*env)->DeleteLocalRef(env, application);
-  (*env)->DeleteLocalRef(env, activity_thread_class);
-  (*env)->DeleteLocalRef(env, thread);
-  (*env)->DeleteLocalRef(env, thread_class);
-}
-
-static void
-bare_worklet_android_on_thread_enter(void *java_vm) {
-  int err;
-
-  JavaVM *vm = (JavaVM *) java_vm;
-
-  JNIEnv *env;
-  err = (*vm)->GetEnv(vm, (void **) &env, JNI_VERSION_1_6);
-  assert(err == JNI_EDETACHED);
-
-  JavaVMAttachArgs args = {
-    JNI_VERSION_1_6,
-    "bare-worklet",
-    NULL,
-  };
-
-  err = (*vm)->AttachCurrentThread(vm, &env, &args);
-  assert(err == JNI_OK);
-
-  bare_worklet_set_context_class_loader(env);
-}
-
-static void
-bare_worklet_android_on_thread_exit(void *java_vm) {
-  JavaVM *vm = (JavaVM *) java_vm;
-
-  JNIEnv *env;
-  int err = (*vm)->GetEnv(vm, (void **) &env, JNI_VERSION_1_6);
-  assert(err == JNI_OK);
-
-  err = (*vm)->DetachCurrentThread(vm);
-  assert(err == JNI_OK);
-}
-
 JNIEXPORT jobject JNICALL
 Java_to_holepunch_bare_kit_Worklet_init(JNIEnv *env, jobject self, jint jmemory_limit, jobject jassets) {
   int err;
@@ -107,8 +25,6 @@ Java_to_holepunch_bare_kit_Worklet_init(JNIEnv *env, jobject self, jint jmemory_
   bare_worklet_context_t *context = malloc(sizeof(bare_worklet_context_t));
 
   context->worklet.data = (void *) context;
-
-  (*env)->GetJavaVM(env, &context->vm);
 
   bare_worklet_options_t options;
 
@@ -121,12 +37,6 @@ Java_to_holepunch_bare_kit_Worklet_init(JNIEnv *env, jobject self, jint jmemory_
   }
 
   err = bare_worklet_init(&context->worklet, &options);
-  assert(err == 0);
-
-  err = bare_worklet_on_thread_enter(&context->worklet, bare_worklet_android_on_thread_enter, context->vm);
-  assert(err == 0);
-
-  err = bare_worklet_on_thread_exit(&context->worklet, bare_worklet_android_on_thread_exit, context->vm);
   assert(err == 0);
 
   if (options.assets) {

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -90,7 +90,6 @@ if(ANDROID)
     bare_worklet
     PRIVATE
       android
-      dl
   )
 
   target_compile_definitions(

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -20,10 +20,19 @@ target_sources(
   PRIVATE
     ipc.h
     ipc.c
+    platform.h
     worklet.c
     worklet.bundle.h
     worklet.h
 )
+
+if(NOT ANDROID)
+  target_sources(
+    bare_worklet
+    PRIVATE
+      platform.c
+  )
+endif()
 
 target_include_directories(
   bare_worklet
@@ -74,12 +83,14 @@ if(ANDROID)
       android/ipc.h
       android/suspension.c
       android/suspension.h
+      android/worklet.c
   )
 
   target_link_libraries(
     bare_worklet
     PRIVATE
       android
+      dl
   )
 
   target_compile_definitions(

--- a/shared/android/worklet.c
+++ b/shared/android/worklet.c
@@ -1,69 +1,9 @@
 #include <assert.h>
-#include <dlfcn.h>
 #include <jni.h>
-#include <stddef.h>
-#include <uv.h>
 
 #include "../platform.h"
 #include "../worklet.h"
-
-typedef jint (*bare_worklet_android_get_created_java_vms_fn)(JavaVM **, jsize, jsize *);
-
-static uv_once_t bare_worklet_android_get_created_java_vms_guard = UV_ONCE_INIT;
-static bare_worklet_android_get_created_java_vms_fn bare_worklet_android_get_created_java_vms_fn_ = NULL;
-
-static void
-bare_worklet_android_on_get_created_java_vms_init() {
-  void *symbol = dlsym(RTLD_DEFAULT, "JNI_GetCreatedJavaVMs");
-
-  if (symbol) {
-    bare_worklet_android_get_created_java_vms_fn_ = (bare_worklet_android_get_created_java_vms_fn) symbol;
-    return;
-  }
-
-  const char *libraries[] = {
-    "libart.so",
-    "libnativehelper.so",
-  };
-
-  for (size_t i = 0; i < sizeof(libraries) / sizeof(libraries[0]); i++) {
-    void *handle = dlopen(libraries[i], RTLD_NOW | RTLD_LOCAL);
-    if (handle == NULL) continue;
-
-    symbol = dlsym(handle, "JNI_GetCreatedJavaVMs");
-    if (symbol == NULL) continue;
-
-    bare_worklet_android_get_created_java_vms_fn_ = (bare_worklet_android_get_created_java_vms_fn) symbol;
-    return;
-  }
-
-  assert(bare_worklet_android_get_created_java_vms_fn_ != NULL);
-}
-
-static bare_worklet_android_get_created_java_vms_fn
-bare_worklet_android_get_created_java_vms() {
-  uv_once(&bare_worklet_android_get_created_java_vms_guard, bare_worklet_android_on_get_created_java_vms_init);
-
-  return bare_worklet_android_get_created_java_vms_fn_;
-}
-
-static uv_once_t bare_worklet_android_java_vm_guard = UV_ONCE_INIT;
-static JavaVM *bare_worklet_android_java_vm = NULL;
-
-static void
-bare_worklet_android_on_java_vm_init() {
-  jsize count = 0;
-  int err = bare_worklet_android_get_created_java_vms()(&bare_worklet_android_java_vm, 1, &count);
-  assert(err == JNI_OK);
-  assert(count == 1);
-}
-
-static JavaVM *
-bare_worklet_android_get_java_vm() {
-  uv_once(&bare_worklet_android_java_vm_guard, bare_worklet_android_on_java_vm_init);
-
-  return bare_worklet_android_java_vm;
-}
+#include "worklet.h"
 
 static void
 bare_worklet_android_set_context_class_loader(JNIEnv *env) {
@@ -111,11 +51,11 @@ bare_worklet_android_set_context_class_loader(JNIEnv *env) {
   (*env)->DeleteLocalRef(env, thread_class);
 }
 
-void
-bare_worklet__platform_on_thread_enter(bare_worklet_t *worklet) {
+static void
+bare_worklet_android_on_thread_enter(void *data) {
   int err;
 
-  JavaVM *vm = bare_worklet_android_get_java_vm();
+  JavaVM *vm = (JavaVM *) data;
 
   JNIEnv *env;
   err = (*vm)->GetEnv(vm, (void **) &env, JNI_VERSION_1_6);
@@ -133,9 +73,9 @@ bare_worklet__platform_on_thread_enter(bare_worklet_t *worklet) {
   bare_worklet_android_set_context_class_loader(env);
 }
 
-void
-bare_worklet__platform_on_thread_exit(bare_worklet_t *worklet) {
-  JavaVM *vm = bare_worklet_android_get_java_vm();
+static void
+bare_worklet_android_on_thread_exit(void *data) {
+  JavaVM *vm = (JavaVM *) data;
 
   JNIEnv *env;
   int err = (*vm)->GetEnv(vm, (void **) &env, JNI_VERSION_1_6);
@@ -146,8 +86,27 @@ bare_worklet__platform_on_thread_exit(bare_worklet_t *worklet) {
 }
 
 int
-bare_worklet__platform_init(bare_worklet_t *worklet) {
-  bare_worklet_android_get_java_vm();
+bare_worklet_android_attach_vm(bare_worklet_t *worklet, JavaVM *vm) {
+  int err;
 
+  if (vm == NULL) return -1;
+
+  err = bare_worklet_on_thread_enter(worklet, bare_worklet_android_on_thread_enter, vm);
+  if (err < 0) return err;
+
+  err = bare_worklet_on_thread_exit(worklet, bare_worklet_android_on_thread_exit, vm);
+  if (err < 0) return err;
+
+  return 0;
+}
+
+void
+bare_worklet__platform_on_thread_enter(bare_worklet_t *worklet) {}
+
+void
+bare_worklet__platform_on_thread_exit(bare_worklet_t *worklet) {}
+
+int
+bare_worklet__platform_init(bare_worklet_t *worklet) {
   return 0;
 }

--- a/shared/android/worklet.c
+++ b/shared/android/worklet.c
@@ -1,0 +1,153 @@
+#include <assert.h>
+#include <dlfcn.h>
+#include <jni.h>
+#include <stddef.h>
+#include <uv.h>
+
+#include "../platform.h"
+#include "../worklet.h"
+
+typedef jint (*bare_worklet_android_get_created_java_vms_fn)(JavaVM **, jsize, jsize *);
+
+static uv_once_t bare_worklet_android_get_created_java_vms_guard = UV_ONCE_INIT;
+static bare_worklet_android_get_created_java_vms_fn bare_worklet_android_get_created_java_vms_fn_ = NULL;
+
+static void
+bare_worklet_android_on_get_created_java_vms_init() {
+  void *symbol = dlsym(RTLD_DEFAULT, "JNI_GetCreatedJavaVMs");
+
+  if (symbol) {
+    bare_worklet_android_get_created_java_vms_fn_ = (bare_worklet_android_get_created_java_vms_fn) symbol;
+    return;
+  }
+
+  const char *libraries[] = {
+    "libart.so",
+    "libnativehelper.so",
+  };
+
+  for (size_t i = 0; i < sizeof(libraries) / sizeof(libraries[0]); i++) {
+    void *handle = dlopen(libraries[i], RTLD_NOW | RTLD_LOCAL);
+    if (handle == NULL) continue;
+
+    symbol = dlsym(handle, "JNI_GetCreatedJavaVMs");
+    if (symbol == NULL) continue;
+
+    bare_worklet_android_get_created_java_vms_fn_ = (bare_worklet_android_get_created_java_vms_fn) symbol;
+    return;
+  }
+
+  assert(bare_worklet_android_get_created_java_vms_fn_ != NULL);
+}
+
+static bare_worklet_android_get_created_java_vms_fn
+bare_worklet_android_get_created_java_vms() {
+  uv_once(&bare_worklet_android_get_created_java_vms_guard, bare_worklet_android_on_get_created_java_vms_init);
+
+  return bare_worklet_android_get_created_java_vms_fn_;
+}
+
+static uv_once_t bare_worklet_android_java_vm_guard = UV_ONCE_INIT;
+static JavaVM *bare_worklet_android_java_vm = NULL;
+
+static void
+bare_worklet_android_on_java_vm_init() {
+  jsize count = 0;
+  int err = bare_worklet_android_get_created_java_vms()(&bare_worklet_android_java_vm, 1, &count);
+  assert(err == JNI_OK);
+  assert(count == 1);
+}
+
+static JavaVM *
+bare_worklet_android_get_java_vm() {
+  uv_once(&bare_worklet_android_java_vm_guard, bare_worklet_android_on_java_vm_init);
+
+  return bare_worklet_android_java_vm;
+}
+
+static void
+bare_worklet_android_set_context_class_loader(JNIEnv *env) {
+  jclass thread_class = (*env)->FindClass(env, "java/lang/Thread");
+  assert(thread_class != NULL);
+
+  jmethodID current_thread = (*env)->GetStaticMethodID(env, thread_class, "currentThread", "()Ljava/lang/Thread;");
+  assert(current_thread != NULL);
+
+  jobject thread = (*env)->CallStaticObjectMethod(env, thread_class, current_thread);
+  assert(thread != NULL);
+  assert(!(*env)->ExceptionCheck(env));
+
+  jclass activity_thread_class = (*env)->FindClass(env, "android/app/ActivityThread");
+  assert(activity_thread_class != NULL);
+
+  jmethodID current_application = (*env)->GetStaticMethodID(env, activity_thread_class, "currentApplication", "()Landroid/app/Application;");
+  assert(current_application != NULL);
+
+  jobject application = (*env)->CallStaticObjectMethod(env, activity_thread_class, current_application);
+  assert(application != NULL);
+  assert(!(*env)->ExceptionCheck(env));
+
+  jclass application_class = (*env)->GetObjectClass(env, application);
+  assert(application_class != NULL);
+
+  jmethodID get_class_loader = (*env)->GetMethodID(env, application_class, "getClassLoader", "()Ljava/lang/ClassLoader;");
+  assert(get_class_loader != NULL);
+
+  jobject class_loader = (*env)->CallObjectMethod(env, application, get_class_loader);
+  assert(class_loader != NULL);
+  assert(!(*env)->ExceptionCheck(env));
+
+  jmethodID set_context_class_loader = (*env)->GetMethodID(env, thread_class, "setContextClassLoader", "(Ljava/lang/ClassLoader;)V");
+  assert(set_context_class_loader != NULL);
+
+  (*env)->CallVoidMethod(env, thread, set_context_class_loader, class_loader);
+  assert(!(*env)->ExceptionCheck(env));
+
+  (*env)->DeleteLocalRef(env, class_loader);
+  (*env)->DeleteLocalRef(env, application_class);
+  (*env)->DeleteLocalRef(env, application);
+  (*env)->DeleteLocalRef(env, activity_thread_class);
+  (*env)->DeleteLocalRef(env, thread);
+  (*env)->DeleteLocalRef(env, thread_class);
+}
+
+void
+bare_worklet__platform_on_thread_enter(bare_worklet_t *worklet) {
+  int err;
+
+  JavaVM *vm = bare_worklet_android_get_java_vm();
+
+  JNIEnv *env;
+  err = (*vm)->GetEnv(vm, (void **) &env, JNI_VERSION_1_6);
+  assert(err == JNI_EDETACHED);
+
+  JavaVMAttachArgs args = {
+    JNI_VERSION_1_6,
+    "bare-worklet",
+    NULL,
+  };
+
+  err = (*vm)->AttachCurrentThread(vm, &env, &args);
+  assert(err == JNI_OK);
+
+  bare_worklet_android_set_context_class_loader(env);
+}
+
+void
+bare_worklet__platform_on_thread_exit(bare_worklet_t *worklet) {
+  JavaVM *vm = bare_worklet_android_get_java_vm();
+
+  JNIEnv *env;
+  int err = (*vm)->GetEnv(vm, (void **) &env, JNI_VERSION_1_6);
+  assert(err == JNI_OK);
+
+  err = (*vm)->DetachCurrentThread(vm);
+  assert(err == JNI_OK);
+}
+
+int
+bare_worklet__platform_init(bare_worklet_t *worklet) {
+  bare_worklet_android_get_java_vm();
+
+  return 0;
+}

--- a/shared/android/worklet.h
+++ b/shared/android/worklet.h
@@ -1,0 +1,19 @@
+#ifndef BARE_KIT_ANDROID_WORKLET_H
+#define BARE_KIT_ANDROID_WORKLET_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <jni.h>
+
+#include "../worklet.h"
+
+int
+bare_worklet_android_attach_vm(bare_worklet_t *worklet, JavaVM *java_vm);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BARE_KIT_ANDROID_WORKLET_H

--- a/shared/platform.c
+++ b/shared/platform.c
@@ -1,0 +1,12 @@
+#include "platform.h"
+
+int
+bare_worklet__platform_init(bare_worklet_t *worklet) {
+  return 0;
+}
+
+void
+bare_worklet__platform_on_thread_enter(bare_worklet_t *worklet) {}
+
+void
+bare_worklet__platform_on_thread_exit(bare_worklet_t *worklet) {}

--- a/shared/platform.h
+++ b/shared/platform.h
@@ -1,0 +1,15 @@
+#ifndef BARE_KIT_PLATFORM_H
+#define BARE_KIT_PLATFORM_H
+
+#include "worklet.h"
+
+int
+bare_worklet__platform_init(bare_worklet_t *worklet);
+
+void
+bare_worklet__platform_on_thread_enter(bare_worklet_t *worklet);
+
+void
+bare_worklet__platform_on_thread_exit(bare_worklet_t *worklet);
+
+#endif // BARE_KIT_PLATFORM_H

--- a/shared/worklet.c
+++ b/shared/worklet.c
@@ -15,6 +15,7 @@
 #include <uv.h>
 
 #include "suspension.h"
+#include "platform.h"
 #include "worklet.bundle.h"
 #include "worklet.h"
 
@@ -35,12 +36,6 @@ struct bare_worklet_state_s {
 
     bare_resume_cb resume;
     void *resume_data;
-
-    bare_worklet_thread_enter_cb thread_enter;
-    void *thread_enter_data;
-
-    bare_worklet_thread_exit_cb thread_exit;
-    void *thread_exit_data;
   } callbacks;
 };
 
@@ -84,6 +79,14 @@ bare_worklet_init(bare_worklet_t *worklet, const bare_worklet_options_t *options
   memset(&state->callbacks, 0, sizeof(state->callbacks));
 
   worklet->state = state;
+
+  err = bare_worklet__platform_init(worklet);
+  if (err < 0) {
+    free(state);
+    worklet->state = NULL;
+
+    return err;
+  }
 
   memset(&worklet->options, 0, sizeof(worklet->options));
 
@@ -139,22 +142,6 @@ int
 bare_worklet_on_resume(bare_worklet_t *worklet, bare_resume_cb cb, void *data) {
   worklet->state->callbacks.resume = cb;
   worklet->state->callbacks.resume_data = data;
-
-  return 0;
-}
-
-int
-bare_worklet_on_thread_enter(bare_worklet_t *worklet, bare_worklet_thread_enter_cb cb, void *data) {
-  worklet->state->callbacks.thread_enter = cb;
-  worklet->state->callbacks.thread_enter_data = data;
-
-  return 0;
-}
-
-int
-bare_worklet_on_thread_exit(bare_worklet_t *worklet, bare_worklet_thread_exit_cb cb, void *data) {
-  worklet->state->callbacks.thread_exit = cb;
-  worklet->state->callbacks.thread_exit_data = data;
 
   return 0;
 }
@@ -382,12 +369,8 @@ bare_worklet__on_thread(void *opaque) {
   bare_worklet_t *worklet = (bare_worklet_t *) opaque;
 
   bare_worklet_state_t *state = worklet->state;
-  bare_worklet_thread_exit_cb thread_exit = state->callbacks.thread_exit;
-  void *thread_exit_data = state->callbacks.thread_exit_data;
 
-  if (state->callbacks.thread_enter) {
-    state->callbacks.thread_enter(state->callbacks.thread_enter_data);
-  }
+  bare_worklet__platform_on_thread_enter(worklet);
 
   uv_sem_t finished;
   err = uv_sem_init(&finished, 0);
@@ -531,7 +514,7 @@ bare_worklet__on_thread(void *opaque) {
   err = bare_suspension_end(&state->suspension);
   assert(err == 0);
 
-  if (thread_exit) thread_exit(thread_exit_data);
+  bare_worklet__platform_on_thread_exit(worklet);
 
   free(state);
 }

--- a/shared/worklet.c
+++ b/shared/worklet.c
@@ -36,6 +36,12 @@ struct bare_worklet_state_s {
 
     bare_resume_cb resume;
     void *resume_data;
+
+    bare_worklet_thread_enter_cb thread_enter;
+    void *thread_enter_data;
+
+    bare_worklet_thread_exit_cb thread_exit;
+    void *thread_exit_data;
   } callbacks;
 };
 
@@ -142,6 +148,22 @@ int
 bare_worklet_on_resume(bare_worklet_t *worklet, bare_resume_cb cb, void *data) {
   worklet->state->callbacks.resume = cb;
   worklet->state->callbacks.resume_data = data;
+
+  return 0;
+}
+
+int
+bare_worklet_on_thread_enter(bare_worklet_t *worklet, bare_worklet_thread_enter_cb cb, void *data) {
+  worklet->state->callbacks.thread_enter = cb;
+  worklet->state->callbacks.thread_enter_data = data;
+
+  return 0;
+}
+
+int
+bare_worklet_on_thread_exit(bare_worklet_t *worklet, bare_worklet_thread_exit_cb cb, void *data) {
+  worklet->state->callbacks.thread_exit = cb;
+  worklet->state->callbacks.thread_exit_data = data;
 
   return 0;
 }
@@ -372,6 +394,13 @@ bare_worklet__on_thread(void *opaque) {
 
   bare_worklet__platform_on_thread_enter(worklet);
 
+  bare_worklet_thread_exit_cb thread_exit = state->callbacks.thread_exit;
+  void *thread_exit_data = state->callbacks.thread_exit_data;
+
+  if (state->callbacks.thread_enter) {
+    state->callbacks.thread_enter(state->callbacks.thread_enter_data);
+  }
+
   uv_sem_t finished;
   err = uv_sem_init(&finished, 0);
   assert(err == 0);
@@ -513,6 +542,8 @@ bare_worklet__on_thread(void *opaque) {
 
   err = bare_suspension_end(&state->suspension);
   assert(err == 0);
+
+  if (thread_exit) thread_exit(thread_exit_data);
 
   bare_worklet__platform_on_thread_exit(worklet);
 

--- a/shared/worklet.h
+++ b/shared/worklet.h
@@ -18,6 +18,8 @@ typedef struct bare_worklet_state_s bare_worklet_state_t;
 typedef struct bare_worklet_push_s bare_worklet_push_t;
 
 typedef void (*bare_worklet_push_cb)(bare_worklet_push_t *, const char *error, const uv_buf_t *reply);
+typedef void (*bare_worklet_thread_enter_cb)(void *data);
+typedef void (*bare_worklet_thread_exit_cb)(void *data);
 
 struct bare_worklet_options_s {
   /**
@@ -111,6 +113,12 @@ bare_worklet_on_idle(bare_worklet_t *worklet, bare_idle_cb cb, void *data);
 
 int
 bare_worklet_on_resume(bare_worklet_t *worklet, bare_resume_cb cb, void *data);
+
+int
+bare_worklet_on_thread_enter(bare_worklet_t *worklet, bare_worklet_thread_enter_cb cb, void *data);
+
+int
+bare_worklet_on_thread_exit(bare_worklet_t *worklet, bare_worklet_thread_exit_cb cb, void *data);
 
 void *
 bare_worklet_get_data(bare_worklet_t *worklet);

--- a/shared/worklet.h
+++ b/shared/worklet.h
@@ -18,8 +18,6 @@ typedef struct bare_worklet_state_s bare_worklet_state_t;
 typedef struct bare_worklet_push_s bare_worklet_push_t;
 
 typedef void (*bare_worklet_push_cb)(bare_worklet_push_t *, const char *error, const uv_buf_t *reply);
-typedef void (*bare_worklet_thread_enter_cb)(void *data);
-typedef void (*bare_worklet_thread_exit_cb)(void *data);
 
 struct bare_worklet_options_s {
   /**
@@ -113,12 +111,6 @@ bare_worklet_on_idle(bare_worklet_t *worklet, bare_idle_cb cb, void *data);
 
 int
 bare_worklet_on_resume(bare_worklet_t *worklet, bare_resume_cb cb, void *data);
-
-int
-bare_worklet_on_thread_enter(bare_worklet_t *worklet, bare_worklet_thread_enter_cb cb, void *data);
-
-int
-bare_worklet_on_thread_exit(bare_worklet_t *worklet, bare_worklet_thread_exit_cb cb, void *data);
 
 void *
 bare_worklet_get_data(bare_worklet_t *worklet);

--- a/win32/worklet.def
+++ b/win32/worklet.def
@@ -7,8 +7,6 @@ EXPORTS
   bare_worklet_on_wakeup
   bare_worklet_on_idle
   bare_worklet_on_resume
-  bare_worklet_on_thread_enter
-  bare_worklet_on_thread_exit
   bare_worklet_get_data
   bare_worklet_set_data
   bare_worklet_start


### PR DESCRIPTION
My previous thread enter/exit changes ended up being implemented in a way that was too limited.

React Native uses the C++ api, not the Java worklet api, so rn/expo examples continued to have issues as the thread enter/exit behavior was never being called.

This pr moves those functions so that they work whether it's the Java or C++ api being used.

It's also a bit of public api thrashing, which isn't great. It seems unlikely those functions were getting any use yet, but still unfortunate.