### PR TITLE
Add bare_worklet_on_exit to detect a self-exiting worklet

### DIFF
--- a/shared/worklet.c
+++ b/shared/worklet.c
@@ -36,6 +36,9 @@ struct bare_worklet_state_s {
 
     bare_resume_cb resume;
     void *resume_data;
+
+    bare_worklet_exit_cb exit;
+    void *exit_data;
   } callbacks;
 };
 
@@ -134,6 +137,14 @@ int
 bare_worklet_on_resume(bare_worklet_t *worklet, bare_resume_cb cb, void *data) {
   worklet->state->callbacks.resume = cb;
   worklet->state->callbacks.resume_data = data;
+
+  return 0;
+}
+
+int
+bare_worklet_on_exit(bare_worklet_t *worklet, bare_worklet_exit_cb cb, void *data) {
+  worklet->state->callbacks.exit = cb;
+  worklet->state->callbacks.exit_data = data;
 
   return 0;
 }
@@ -488,6 +499,8 @@ bare_worklet__on_thread(void *opaque) {
   assert(err == 0);
 
   state->finished = true;
+
+  if (state->callbacks.exit) state->callbacks.exit(worklet, state->callbacks.exit_data);
 
   uv_sem_wait(&finished);
 

--- a/shared/worklet.h
+++ b/shared/worklet.h
@@ -19,6 +19,8 @@ typedef struct bare_worklet_push_s bare_worklet_push_t;
 
 typedef void (*bare_worklet_push_cb)(bare_worklet_push_t *, const char *error, const uv_buf_t *reply);
 
+typedef void (*bare_worklet_exit_cb)(bare_worklet_t *, void *data);
+
 struct bare_worklet_options_s {
   /**
    * The memory limit of each JavaScript heap. By default, the limit will be
@@ -111,6 +113,16 @@ bare_worklet_on_idle(bare_worklet_t *worklet, bare_idle_cb cb, void *data);
 
 int
 bare_worklet_on_resume(bare_worklet_t *worklet, bare_resume_cb cb, void *data);
+
+/**
+ * Register a callback invoked on the worklet thread when the worklet stops
+ * running JavaScript, whether it exited on its own (`Bare.exit()` or the event
+ * loop draining) or was terminated by the host. This lets the host detect a
+ * worklet that has stopped and tear it down. The callback fires before the
+ * worklet parks waiting for `bare_worklet_destroy`.
+ */
+int
+bare_worklet_on_exit(bare_worklet_t *worklet, bare_worklet_exit_cb cb, void *data);
 
 void *
 bare_worklet_get_data(bare_worklet_t *worklet);

--- a/test/shared/CMakeLists.txt
+++ b/test/shared/CMakeLists.txt
@@ -3,6 +3,7 @@ list(APPEND tests
   worklet-destroy-before-start
   worklet-ipc
   worklet-ipc-large-write
+  worklet-self-exit
   worklet-suspend-resume
   worklet-terminate-after-suspend
 )

--- a/test/shared/worklet-self-exit.c
+++ b/test/shared/worklet-self-exit.c
@@ -1,0 +1,35 @@
+#include <uv.h>
+
+#include "../../shared/worklet.h"
+
+static bool exit_called = false;
+
+static void
+on_worklet_exit(bare_worklet_t *worklet, void *data) {
+  exit_called = true;
+}
+
+int
+main() {
+  int e;
+
+  bare_worklet_t worklet;
+  e = bare_worklet_init(&worklet, NULL);
+  assert(e == 0);
+
+  e = bare_worklet_on_exit(&worklet, on_worklet_exit, NULL);
+  assert(e == 0);
+
+  char *code = "setTimeout(() => Bare.exit(0), 10)";
+
+  uv_buf_t source = uv_buf_init(code, strlen(code));
+
+  e = bare_worklet_start(&worklet, "app.js", &source, 0, NULL);
+  assert(e == 0);
+
+  uv_sleep(500); // Let the worklet exit on its own and flush the callback
+
+  assert(exit_called);
+
+  bare_worklet_destroy(&worklet);
+}


### PR DESCRIPTION
A worklet that exits on its own - `Bare.exit()` or the event loop simply draining - gave the host no signal. The worklet thread parks in `bare_worklet__on_thread` at `uv_sem_wait(&finished)` after `bare_run` returns, and only unparks when the host calls `bare_worklet_destroy`. Teardown (which would close the JS-side IPC fd) runs after the park, so the host's IPC read never EOFs and a dead worklet is indistinguishable from an idle one.

Add `bare_worklet_on_exit(worklet, cb, data)`, fired on the worklet thread right after `bare_run` returns and before the park, so the host can detect a stopped worklet and tear it down.

Notes:
- The callback carries no exit code. Bare only exposes the exit code via `bare_teardown` (after the park) and offers no getter, so enriching it needs an upstream `bare` change - left as a follow-up.
- It fires for host-initiated `terminate` too, not only self-exit; the host can ignore it.
- Wiring this into the Objective-C `BareWorklet` / Java `Worklet` surfaces (so bare-kit-swift can use it) is a separate follow-up; this PR adds the C primitive and its test.

Test: `worklet-self-exit.c` registers the callback, runs `setTimeout(() => Bare.exit(0), 10)`, and asserts the callback fires. Confirmed failing without the fix.

Refs #83.