### PR TITLE
Signal IPC end-of-stream as nil in BareIPC read:completion:

### DIFF
--- a/apple/BareKit/BareKit.m
+++ b/apple/BareKit/BareKit.m
@@ -377,20 +377,29 @@ bare_ipc__on_poll(bare_ipc_poll_t *poll, int events) {
 }
 
 - (void)read:(void (^_Nonnull)(NSData *_Nullable data, NSError *_Nullable error))completion {
-  NSData *data = [self read];
+  int err;
 
-  if (data) {
-    completion(data, nil);
-  } else {
+  void *data;
+  size_t len;
+  err = bare_ipc_read(&_ipc, &data, &len);
+  assert(err == 0 || err == bare_ipc_would_block);
+
+  if (err == bare_ipc_would_block) {
     self.readable = ^(BareIPC *ipc) {
-      NSData *data = [self read];
+      self.readable = nil;
 
-      if (data) {
-        self.readable = nil;
-
-        completion(data, nil);
-      }
+      [self read:completion];
     };
+
+    return;
+  }
+
+  // A successful read of zero bytes is end-of-stream; signal it as nil rather
+  // than an empty buffer so consumers can detect a closed IPC.
+  if (len == 0) {
+    completion(nil, nil);
+  } else {
+    completion([[NSData alloc] initWithBytes:data length:len], nil);
   }
 }
 

--- a/test/apple/CMakeLists.txt
+++ b/test/apple/CMakeLists.txt
@@ -1,5 +1,6 @@
 list(APPEND tests
   worklet-ipc
+  worklet-ipc-eof
   worklet-ipc-large-write
   worklet-push
   worklet-push-error

--- a/test/apple/worklet-ipc-eof.m
+++ b/test/apple/worklet-ipc-eof.m
@@ -1,0 +1,25 @@
+#import <BareKit/BareKit.h>
+#import <Foundation/Foundation.h>
+
+int
+main() {
+  BareWorklet *worklet = [[BareWorklet alloc] initWithConfiguration:nil];
+
+  NSString *source = @"BareKit.IPC.write('bye'); BareKit.IPC.end()";
+
+  [worklet start:@"/app.js" source:[source dataUsingEncoding:NSUTF8StringEncoding] arguments:@[]];
+
+  BareIPC *ipc = [[BareIPC alloc] initWithWorklet:worklet];
+
+  [ipc read:^(NSData *_Nullable data, NSError *_Nullable error) {
+    assert(data != nil); // The message arrives as its own read, before EOF
+
+    [ipc read:^(NSData *_Nullable data, NSError *_Nullable error) {
+      assert(data == nil); // EOF must be signalled as nil, not an empty buffer
+
+      exit(0);
+    }];
+  }];
+
+  [[NSRunLoop currentRunLoop] run];
+}


### PR DESCRIPTION
`bare_ipc_read` reports EOF as a successful zero-length read (`err == 0`, `len == 0`; see `shared/posix/ipc.c`). The async `-[BareIPC read:completion:]` wrapped that as a non-nil empty `NSData` and completed with it, so an `AsyncSequence` consumer (bare-kit-swift's `for try await chunk in ipc`) received an empty `Data` instead of `nil` and never terminated.

Read directly via `bare_ipc_read` and branch on the result rather than routing through `-read` (which collapses both would-block and EOF to `nil` and so cannot distinguish them):
- `would_block` -> arm the readable handler and retry
- `len == 0` -> `completion(nil, nil)` (end-of-stream)
- otherwise -> deliver the data

Test: `worklet-ipc-eof.m` has the worklet `write('bye')` then `end()`, asserts the first read returns the message and the second completes with `nil`. Confirmed failing (empty buffer) without the fix.

Independent of #85, but both are needed end to end for the self-exit case: #85 lets the host learn the worklet exited and tear it down (closing the JS-side fd -> EOF), and this PR turns that EOF into a terminated sequence.

Refs #83.