### PR TITLE
Use the Gradle wrapper in CI

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -70,7 +70,7 @@ jobs:
           java-version: 21
       - run: npm install --global cmake-runtime ninja-runtime
       - run: npm install
-      - run: gradle aR
+      - run: ./gradlew aR
   linux:
     strategy:
       matrix:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,7 +89,7 @@ jobs:
           java-version: 21
       - run: npm install --global cmake-runtime ninja-runtime
       - run: npm install
-      - run: gradle aR
+      - run: ./gradlew aR
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.platform }}


### PR DESCRIPTION
The android CI job runs `gradle aR` using the runner's system Gradle. The `ubuntu-24.04` image moved to Gradle 9.6.0, which removed `org.gradle.api.problems.internal.InternalProblems` - an internal API that Android Gradle Plugin 8.12.0 relies on - so `com.android.library` fails to apply and the job dies before building:

> Plugin 'com.android.internal.library' relies on 'org.gradle.api.problems.internal.InternalProblems', a Gradle internal API that was removed in Gradle 9.6.0.

The repo already pins Gradle 8.14.3 in `gradle/wrapper/gradle-wrapper.properties`, and AGP 8.12.0 is compatible with it. CI just wasn't using it. Switch `gradle aR` -> `./gradlew aR` in both `integrate.yml` and `publish.yml` so CI uses the committed wrapper version and is no longer at the mercy of the runner image's Gradle.

This is the minimal, low-risk fix. A follow-up could modernize to a Gradle 9.6-compatible AGP (and bump the wrapper to match) if we want to track current Gradle, but that is a larger change with its own ripple effects (min Gradle/JDK, build-tools, behavior) and shouldn't gate unbreaking CI.