### PR TITLE
Close Bare.IPC when the worklet process exits

### DIFF
--- a/shared/win32/ipc.c
+++ b/shared/win32/ipc.c
@@ -23,6 +23,13 @@ bare_ipc__on_alloc(uv_handle_t *handle, size_t suggested_size, uv_buf_t *buf) {
 
 void
 bare_ipc__on_read(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf) {
+  // End-of-stream when the worklet closes its IPC. Stop reading rather than
+  // aborting; surfacing EOF to the host is not yet implemented for win32.
+  if (nread == UV_EOF) {
+    uv_read_stop(stream);
+    return;
+  }
+
   assert(nread >= 0);
 
   if (nread == 0) {

--- a/shared/worklet.js
+++ b/shared/worklet.js
@@ -20,7 +20,9 @@ const ipc = new IPC(ports[0])
 
 Bare.IPC = ipc
 
-Bare.on('suspend', () => ipc.unref()).on('resume', () => ipc.ref())
+Bare.on('suspend', () => ipc.unref())
+  .on('resume', () => ipc.ref())
+  .on('exit', () => ipc.destroy())
 
 class BareKit extends EventEmitter {
   constructor() {

--- a/test/shared/CMakeLists.txt
+++ b/test/shared/CMakeLists.txt
@@ -1,8 +1,10 @@
 list(APPEND tests
   worklet-assets
   worklet-destroy-before-start
+  worklet-exit-eof
   worklet-ipc
   worklet-ipc-large-write
+  worklet-jsend-eof
   worklet-suspend-resume
   worklet-terminate-after-suspend
 )

--- a/test/shared/CMakeLists.txt
+++ b/test/shared/CMakeLists.txt
@@ -1,13 +1,20 @@
 list(APPEND tests
   worklet-assets
   worklet-destroy-before-start
-  worklet-exit-eof
   worklet-ipc
   worklet-ipc-large-write
-  worklet-jsend-eof
   worklet-suspend-resume
   worklet-terminate-after-suspend
 )
+
+# The win32 IPC layer does not yet surface end-of-stream, so the EOF tests only
+# run on platforms with the posix read path.
+if(NOT WIN32)
+  list(APPEND tests
+    worklet-exit-eof
+    worklet-jsend-eof
+  )
+endif()
 
 execute_process(
   COMMAND node fixtures/generate.js

--- a/test/shared/worklet-exit-eof.c
+++ b/test/shared/worklet-exit-eof.c
@@ -1,0 +1,48 @@
+#include <uv.h>
+
+#include "../../shared/ipc.h"
+#include "../../shared/worklet.h"
+
+// When the worklet exits on its own (Bare.exit()), Bare.IPC is closed as part
+// of process exit, so the host read reaches EOF (returns 0) without the host
+// having to call terminate/destroy first.
+
+int
+main() {
+  int e;
+
+  bare_worklet_t worklet;
+  e = bare_worklet_init(&worklet, NULL);
+  assert(e == 0);
+
+  char *code = "setTimeout(() => Bare.exit(0), 50)";
+
+  uv_buf_t source = uv_buf_init(code, strlen(code));
+
+  e = bare_worklet_start(&worklet, "app.js", &source, 0, NULL);
+  assert(e == 0);
+
+  bare_ipc_t ipc;
+  e = bare_ipc_init(&ipc, &worklet);
+  assert(e == 0);
+
+  void *data;
+  size_t len;
+
+  bool eof = false;
+  for (int i = 0; i < 200; i++) {
+    e = bare_ipc_read(&ipc, &data, &len);
+    assert(e == 0 || e == bare_ipc_would_block);
+    if (e == 0 && len == 0) {
+      eof = true;
+      break;
+    }
+    uv_sleep(10);
+  }
+
+  assert(eof); // The self-exit closed Bare.IPC and the host saw EOF
+
+  bare_ipc_destroy(&ipc);
+
+  bare_worklet_destroy(&worklet);
+}

--- a/test/shared/worklet-jsend-eof.c
+++ b/test/shared/worklet-jsend-eof.c
@@ -1,0 +1,49 @@
+#include <uv.h>
+
+#include "../../shared/ipc.h"
+#include "../../shared/worklet.h"
+
+// Corroborates worklet-exit-no-eof: the host EOF comes from the JS side. When
+// the worklet ends its Bare.IPC (closing the b1 write end), the host read
+// returns 0 (EOF) - the signal the bindings turn into (nil, nil).
+
+int
+main() {
+  int e;
+
+  bare_worklet_t worklet;
+  e = bare_worklet_init(&worklet, NULL);
+  assert(e == 0);
+
+  char *code = "setTimeout(() => Bare.IPC.end(), 50)";
+
+  uv_buf_t source = uv_buf_init(code, strlen(code));
+
+  e = bare_worklet_start(&worklet, "app.js", &source, 0, NULL);
+  assert(e == 0);
+
+  bare_ipc_t ipc;
+  e = bare_ipc_init(&ipc, &worklet);
+  assert(e == 0);
+
+  void *data;
+  size_t len;
+
+  // Poll for up to ~2s for EOF. Expect read to return 0 once b1 closes.
+  bool eof = false;
+  for (int i = 0; i < 200; i++) {
+    e = bare_ipc_read(&ipc, &data, &len);
+    assert(e == 0 || e == bare_ipc_would_block);
+    if (e == 0 && len == 0) {
+      eof = true;
+      break;
+    }
+    uv_sleep(10);
+  }
+
+  assert(eof); // The JS-side end reached the host as EOF
+
+  bare_ipc_destroy(&ipc);
+
+  bare_worklet_destroy(&worklet);
+}


### PR DESCRIPTION
A worklet that exits on its own - `Bare.exit()` or the event loop draining - left its IPC stream open. The worklet thread parks waiting for `bare_worklet_destroy` before teardown closes the pipes, so the host's read never reached EOF and a stopped worklet was indistinguishable from an idle one (#83).

Tie the IPC stream's lifetime to the process, per the `Bare.IPC` convention: close `Bare.IPC` on the `exit` event. The JS-side write end then closes, so the host's read reaches EOF without the host having to call `terminate`/`destroy` first.

No C change is needed: libuv's `uv_close` closes the underlying fd synchronously (only the JS `close` event is deferred), so the descriptor is closed before `bare_run` returns and the thread parks.

Tests (`test/shared`):
- `worklet-exit-eof` - worklet does `Bare.exit(0)`; the host read reaches EOF (returns 0).
- `worklet-jsend-eof` - worklet does `Bare.IPC.end()`; same, covering the explicit-end path.

This supersedes #85 (a `bare_worklet_on_exit` callback) - the host now detects exit via EOF directly, so no new C API is required. The binding-side complement (surfacing the EOF as `(nil, nil)`) is #86.