### PR TITLE
Signal IPC end-of-stream as null in Android IPC.read

### DIFF
--- a/android/src/main/java/to/holepunch/bare/kit/IPC.java
+++ b/android/src/main/java/to/holepunch/bare/kit/IPC.java
@@ -100,8 +100,10 @@ public class IPC implements Closeable {
   read(ReadCallback callback) {
     ByteBuffer data1 = read();
 
+    // A zero-length read is end-of-stream; signal it as null rather than an
+    // empty buffer so consumers can detect a closed IPC.
     if (data1 != null) {
-      callback.apply(data1, null);
+      callback.apply(data1.limit() == 0 ? null : data1, null);
     } else {
       readable(() -> {
         ByteBuffer data2 = read();
@@ -109,7 +111,7 @@ public class IPC implements Closeable {
         if (data2 != null) {
           readable(null);
 
-          callback.apply(data2, null);
+          callback.apply(data2.limit() == 0 ? null : data2, null);
         }
       });
     }


### PR DESCRIPTION
The Android binding has the same EOF defect the Apple one had (#86). `bare_ipc_read` reports EOF as a zero-length successful read; the JNI (`IPC.c`) maps that to a non-null, zero-capacity `ByteBuffer`, and `IPC.read(ReadCallback)` then sees `data != null` and delivers the empty buffer to the callback - never signalling end-of-stream. Since a closed fd stays readable, a consumer reading in a loop just gets empty buffers indefinitely and can't tell the IPC closed.

Treat a zero-length read as EOF and pass `null` to the callback (data `null`, no exception), mirroring the `(nil, nil)` convention from #86. No JNI change is needed: would-block already returns `null` from the native `read`, while EOF returns a `limit() == 0` buffer, so the two are distinguishable in Java.

Scope note: the synchronous `read()` is left as-is (it returns the empty buffer on EOF), matching the choice in #86 to leave the sync `-read` untouched.

Testing caveat: there's no binding-level unit test on Android (the only Android tests are instrumentation, which need an emulator and don't run in `gradle aR`), so this rests on inspection and parity with the Apple fix, whose EOF behaviour is covered by `ctest` on darwin. The shared C-side EOF semantics this relies on are exercised there.

Refs #83.