### PR TITLE
Surface IPC end-of-stream on win32

### DIFF
--- a/shared/win32/ipc.c
+++ b/shared/win32/ipc.c
@@ -23,10 +23,19 @@ bare_ipc__on_alloc(uv_handle_t *handle, size_t suggested_size, uv_buf_t *buf) {
 
 void
 bare_ipc__on_read(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf) {
-  // End-of-stream when the worklet closes its IPC. Stop reading rather than
-  // aborting; surfacing EOF to the host is not yet implemented for win32.
+  bare_ipc_t *ipc = (bare_ipc_t *) uv_handle_get_data((uv_handle_t *) stream);
+
+  // End-of-stream when the worklet closes its IPC. Mark EOF and notify the
+  // reader so a subsequent bare_ipc_read() returns it as a zero-length read.
   if (nread == UV_EOF) {
     uv_read_stop(stream);
+
+    uv_mutex_lock(&ipc->reading);
+    ipc->eof = true;
+    uv_mutex_unlock(&ipc->reading);
+
+    if (ipc->poll && ipc->poll->cb) ipc->poll->cb(ipc->poll, bare_ipc_readable);
+
     return;
   }
 
@@ -40,8 +49,6 @@ bare_ipc__on_read(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf) {
 
   err = uv_read_stop(stream);
   assert(err == 0);
-
-  bare_ipc_t *ipc = (bare_ipc_t *) uv_handle_get_data((uv_handle_t *) stream);
 
   uv_mutex_lock(&ipc->reading);
 
@@ -148,6 +155,7 @@ bare_ipc_init(bare_ipc_t *ipc, bare_worklet_t *worklet) {
   assert(err == 0);
 
   ipc->read_buffer.len = 0;
+  ipc->eof = false;
   ipc->poll = NULL;
 
   uv_barrier_wait(&ipc->ready);
@@ -179,6 +187,15 @@ bare_ipc_read(bare_ipc_t *ipc, void **data, size_t *len) {
     *data = ipc->read_buffer.base;
     *len = ipc->read_buffer.len;
     ipc->read_buffer.len = 0;
+
+    uv_mutex_unlock(&ipc->reading);
+
+    return 0;
+  }
+
+  if (ipc->eof) {
+    *data = ipc->read_buffer.base;
+    *len = 0;
 
     uv_mutex_unlock(&ipc->reading);
 

--- a/shared/win32/ipc.h
+++ b/shared/win32/ipc.h
@@ -5,6 +5,7 @@
 extern "C" {
 #endif
 
+#include <stdbool.h>
 #include <uv.h>
 
 #include "../ipc.h"
@@ -12,6 +13,8 @@ extern "C" {
 struct bare_ipc_s {
   int incoming;
   int outgoing;
+
+  bool eof;
 
   struct {
     char base[BARE_IPC_READ_BUFFER_SIZE];

--- a/shared/worklet.c
+++ b/shared/worklet.c
@@ -489,6 +489,12 @@ bare_worklet__on_thread(void *opaque) {
 
   state->finished = true;
 
+  // The 'exit' handler closes Bare.IPC. Flush the loop so the close completes
+  // and the host sees EOF before we park waiting for teardown. This is a no-op
+  // where uv_close is synchronous (posix) but is required on platforms where
+  // the close only completes via the loop (win32).
+  uv_run(&loop, UV_RUN_NOWAIT);
+
   uv_sem_wait(&finished);
 
   uv_sem_destroy(&finished);

--- a/test/shared/CMakeLists.txt
+++ b/test/shared/CMakeLists.txt
@@ -1,20 +1,13 @@
 list(APPEND tests
   worklet-assets
   worklet-destroy-before-start
+  worklet-exit-eof
   worklet-ipc
   worklet-ipc-large-write
+  worklet-jsend-eof
   worklet-suspend-resume
   worklet-terminate-after-suspend
 )
-
-# The win32 IPC layer does not yet surface end-of-stream, so the EOF tests only
-# run on platforms with the posix read path.
-if(NOT WIN32)
-  list(APPEND tests
-    worklet-exit-eof
-    worklet-jsend-eof
-  )
-endif()
 
 execute_process(
   COMMAND node fixtures/generate.js

--- a/test/shared/worklet-exit-eof.c
+++ b/test/shared/worklet-exit-eof.c
@@ -4,43 +4,72 @@
 #include "../../shared/worklet.h"
 
 // When the worklet exits on its own (Bare.exit()), Bare.IPC is closed as part
-// of process exit, so the host read reaches EOF (returns 0) without the host
-// having to call terminate/destroy first.
+// of process exit, so the host's read reaches EOF (a zero-length read) without
+// the host having to call terminate/destroy first.
 
-int
-main() {
-  int e;
+static uv_async_t finished;
+static bool eof = false;
 
-  bare_worklet_t worklet;
-  e = bare_worklet_init(&worklet, NULL);
-  assert(e == 0);
-
-  char *code = "setTimeout(() => Bare.exit(0), 50)";
-
-  uv_buf_t source = uv_buf_init(code, strlen(code));
-
-  e = bare_worklet_start(&worklet, "app.js", &source, 0, NULL);
-  assert(e == 0);
-
-  bare_ipc_t ipc;
-  e = bare_ipc_init(&ipc, &worklet);
-  assert(e == 0);
+static void
+on_poll(bare_ipc_poll_t *poll, int events) {
+  if ((events & bare_ipc_readable) == 0) return;
 
   void *data;
   size_t len;
+  int err = bare_ipc_read(bare_ipc_poll_get_ipc(poll), &data, &len);
+  assert(err == 0 || err == bare_ipc_would_block);
 
-  bool eof = false;
-  for (int i = 0; i < 200; i++) {
-    e = bare_ipc_read(&ipc, &data, &len);
-    assert(e == 0 || e == bare_ipc_would_block);
-    if (e == 0 && len == 0) {
-      eof = true;
-      break;
-    }
-    uv_sleep(10);
+  if (err == 0 && len == 0) {
+    eof = true;
+
+    bare_ipc_poll_stop(poll);
+
+    uv_async_send(&finished);
   }
+}
+
+static void
+on_finish(uv_async_t *handle) {
+  uv_close((uv_handle_t *) handle, NULL);
+}
+
+int
+main() {
+  int err;
+
+  uv_loop_t *loop = uv_default_loop();
+  err = uv_async_init(loop, &finished, on_finish);
+  assert(err == 0);
+
+  bare_worklet_t worklet;
+  err = bare_worklet_init(&worklet, NULL);
+  assert(err == 0);
+
+  char *code = "setTimeout(() => Bare.exit(0), 50)";
+  uv_buf_t source = uv_buf_init(code, strlen(code));
+  err = bare_worklet_start(&worklet, "app.js", &source, 0, NULL);
+  assert(err == 0);
+
+  bare_ipc_t ipc;
+  err = bare_ipc_init(&ipc, &worklet);
+  assert(err == 0);
+
+  bare_ipc_poll_t poll;
+  err = bare_ipc_poll_init(&poll, &ipc);
+  assert(err == 0);
+
+  err = bare_ipc_poll_start(&poll, bare_ipc_readable, on_poll);
+  assert(err == 0);
+
+  err = uv_run(loop, UV_RUN_DEFAULT);
+  assert(err == 0);
 
   assert(eof); // The self-exit closed Bare.IPC and the host saw EOF
+
+  err = uv_loop_close(loop);
+  assert(err == 0);
+
+  bare_ipc_poll_destroy(&poll);
 
   bare_ipc_destroy(&ipc);
 

--- a/test/shared/worklet-jsend-eof.c
+++ b/test/shared/worklet-jsend-eof.c
@@ -3,45 +3,73 @@
 #include "../../shared/ipc.h"
 #include "../../shared/worklet.h"
 
-// Corroborates worklet-exit-no-eof: the host EOF comes from the JS side. When
-// the worklet ends its Bare.IPC (closing the b1 write end), the host read
-// returns 0 (EOF) - the signal the bindings turn into (nil, nil).
+// When the worklet ends its Bare.IPC (closing the write end), the host's read
+// reaches EOF (a zero-length read) - the signal the bindings turn into a null
+// read. This covers the explicit end() path, independent of process exit.
 
-int
-main() {
-  int e;
+static uv_async_t finished;
+static bool eof = false;
 
-  bare_worklet_t worklet;
-  e = bare_worklet_init(&worklet, NULL);
-  assert(e == 0);
-
-  char *code = "setTimeout(() => Bare.IPC.end(), 50)";
-
-  uv_buf_t source = uv_buf_init(code, strlen(code));
-
-  e = bare_worklet_start(&worklet, "app.js", &source, 0, NULL);
-  assert(e == 0);
-
-  bare_ipc_t ipc;
-  e = bare_ipc_init(&ipc, &worklet);
-  assert(e == 0);
+static void
+on_poll(bare_ipc_poll_t *poll, int events) {
+  if ((events & bare_ipc_readable) == 0) return;
 
   void *data;
   size_t len;
+  int err = bare_ipc_read(bare_ipc_poll_get_ipc(poll), &data, &len);
+  assert(err == 0 || err == bare_ipc_would_block);
 
-  // Poll for up to ~2s for EOF. Expect read to return 0 once b1 closes.
-  bool eof = false;
-  for (int i = 0; i < 200; i++) {
-    e = bare_ipc_read(&ipc, &data, &len);
-    assert(e == 0 || e == bare_ipc_would_block);
-    if (e == 0 && len == 0) {
-      eof = true;
-      break;
-    }
-    uv_sleep(10);
+  if (err == 0 && len == 0) {
+    eof = true;
+
+    bare_ipc_poll_stop(poll);
+
+    uv_async_send(&finished);
   }
+}
+
+static void
+on_finish(uv_async_t *handle) {
+  uv_close((uv_handle_t *) handle, NULL);
+}
+
+int
+main() {
+  int err;
+
+  uv_loop_t *loop = uv_default_loop();
+  err = uv_async_init(loop, &finished, on_finish);
+  assert(err == 0);
+
+  bare_worklet_t worklet;
+  err = bare_worklet_init(&worklet, NULL);
+  assert(err == 0);
+
+  char *code = "setTimeout(() => Bare.IPC.end(), 50)";
+  uv_buf_t source = uv_buf_init(code, strlen(code));
+  err = bare_worklet_start(&worklet, "app.js", &source, 0, NULL);
+  assert(err == 0);
+
+  bare_ipc_t ipc;
+  err = bare_ipc_init(&ipc, &worklet);
+  assert(err == 0);
+
+  bare_ipc_poll_t poll;
+  err = bare_ipc_poll_init(&poll, &ipc);
+  assert(err == 0);
+
+  err = bare_ipc_poll_start(&poll, bare_ipc_readable, on_poll);
+  assert(err == 0);
+
+  err = uv_run(loop, UV_RUN_DEFAULT);
+  assert(err == 0);
 
   assert(eof); // The JS-side end reached the host as EOF
+
+  err = uv_loop_close(loop);
+  assert(err == 0);
+
+  bare_ipc_poll_destroy(&poll);
 
   bare_ipc_destroy(&ipc);
 


### PR DESCRIPTION
Follow-up to #88 / #83, closing the win32 gap tracked in #91.

#88 makes a worklet close `Bare.IPC` on exit so the host reads EOF and can detect a stopped worklet. That worked on the posix IPC path but not win32, whose IPC layer had no end-of-stream support: `bare_ipc_read` only drained a buffer (never returned EOF), and `bare_ipc__on_read` asserted `nread >= 0`, so a real `UV_EOF` would abort. #88 scoped the EOF tests off win32 as a stopgap.

This adds the missing EOF path:
- `bare_ipc__on_read`: on `UV_EOF`, mark an `eof` flag, stop reading, and fire the readable poll so the consumer gets notified.
- `bare_ipc_read`: return a zero-length read (`len 0`) once EOF is reached and the buffer is drained.
- `worklet.c`: flush the loop (`uv_run(&loop, UV_RUN_NOWAIT)`) after `bare_run` returns - a no-op where `uv_close` is synchronous (posix), but required on win32 so the worklet's own IPC close completes before it parks.
- Rewrote `worklet-exit-eof` / `worklet-jsend-eof` to be poll-based (the portable read model) and re-enabled them on win32.

Validation: posix locally (darwin, full suite 13/13, EOF tests 5/5 stable); win32 via the CI `Test / win32-*` jobs, which now run the re-enabled EOF tests on real Windows.

The win32 IPC layer is yours by design - happy to adjust the shape (e.g. how EOF is surfaced through the poll) if you'd prefer it done differently.