### PR TITLE
Add an in-process message queue primitive

### DIFF
--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -21,6 +21,8 @@ target_sources(
     events.h
     ipc.h
     ipc.c
+    queue.h
+    queue.c
     worklet.c
     worklet.bundle.h
     worklet.h

--- a/shared/queue.c
+++ b/shared/queue.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <uv.h>
@@ -88,6 +89,13 @@ bare_queue_open_uv(bare_queue_t *queue, uv_loop_t *loop, bare_queue_recv_cb on_r
   queue->on_recv_uv = on_recv;
   queue->uv_open = true;
 
+  // Catch up on anything the host queued before we opened.
+  uv_mutex_lock(&queue->lock);
+  bool pending = queue->to_uv.head != queue->to_uv.tail;
+  uv_mutex_unlock(&queue->lock);
+
+  if (pending) uv_async_send(&queue->async);
+
   return &queue->uv_port;
 }
 
@@ -95,6 +103,13 @@ bare_queue_port_t *
 bare_queue_open_thread(bare_queue_t *queue, bare_queue_signal_cb on_signal) {
   queue->on_signal_thread = on_signal;
   queue->thread_open = true;
+
+  // Catch up on anything the worklet queued before we opened.
+  uv_mutex_lock(&queue->lock);
+  bool pending = queue->to_thread.head != queue->to_thread.tail;
+  uv_mutex_unlock(&queue->lock);
+
+  if (pending && on_signal) on_signal(&queue->thread_port);
 
   return &queue->thread_port;
 }
@@ -104,6 +119,10 @@ bare_queue_write(bare_queue_port_t *port, const void *data, size_t len) {
   bare_queue_t *queue = port->queue;
 
   if (len == 0) return 0;
+
+  // Cap the copied span so the returned byte count never overflows the int
+  // return value or aliases a negative status. Callers write the rest.
+  if (len > INT_MAX) len = INT_MAX;
 
   bare_queue_ring_t *ring = port->is_uv ? &queue->to_thread : &queue->to_uv;
 

--- a/shared/queue.c
+++ b/shared/queue.c
@@ -1,0 +1,219 @@
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
+#include <uv.h>
+
+#include "queue.h"
+
+#define BARE_QUEUE_MASK (BARE_QUEUE_CAPACITY - 1)
+
+static bool
+bare_queue__ring_push(bare_queue_ring_t *ring, void *base, size_t len) {
+  int next = (ring->head + 1) & BARE_QUEUE_MASK;
+
+  if (next == ring->tail) return false;
+
+  ring->slots[ring->head].base = base;
+  ring->slots[ring->head].len = len;
+  ring->head = next;
+
+  return true;
+}
+
+static bool
+bare_queue__ring_shift(bare_queue_ring_t *ring, bare_queue_message_t *message) {
+  if (ring->tail == ring->head) return false;
+
+  *message = ring->slots[ring->tail];
+  ring->tail = (ring->tail + 1) & BARE_QUEUE_MASK;
+
+  return true;
+}
+
+static void
+bare_queue__signal_uv(bare_queue_t *queue) {
+  if (queue->uv_open) uv_async_send(&queue->async);
+}
+
+static void
+bare_queue__signal_thread(bare_queue_t *queue) {
+  if (queue->thread_open && queue->on_signal_thread) queue->on_signal_thread(&queue->thread_port);
+}
+
+static void
+bare_queue__on_wakeup_uv(uv_async_t *async) {
+  bare_queue_t *queue = (bare_queue_t *) async->data;
+
+  if (queue->on_recv_uv) queue->on_recv_uv(&queue->uv_port);
+}
+
+void
+bare_queue_init(bare_queue_t *queue) {
+  int err;
+
+  memset(&queue->to_uv, 0, sizeof(queue->to_uv));
+  memset(&queue->to_thread, 0, sizeof(queue->to_thread));
+
+  queue->uv_open = false;
+  queue->thread_open = false;
+  queue->uv_closed = false;
+  queue->thread_closed = false;
+
+  queue->on_signal_thread = NULL;
+  queue->on_recv_uv = NULL;
+  queue->on_close = NULL;
+
+  queue->uv_port.queue = queue;
+  queue->uv_port.is_uv = true;
+  queue->uv_port.held = NULL;
+  queue->uv_port.data = NULL;
+
+  queue->thread_port.queue = queue;
+  queue->thread_port.is_uv = false;
+  queue->thread_port.held = NULL;
+  queue->thread_port.data = NULL;
+
+  err = uv_mutex_init(&queue->lock);
+  assert(err == 0);
+}
+
+bare_queue_port_t *
+bare_queue_open_uv(bare_queue_t *queue, uv_loop_t *loop, bare_queue_recv_cb on_recv) {
+  int err;
+
+  err = uv_async_init(loop, &queue->async, bare_queue__on_wakeup_uv);
+  assert(err == 0);
+
+  queue->async.data = queue;
+  queue->on_recv_uv = on_recv;
+  queue->uv_open = true;
+
+  return &queue->uv_port;
+}
+
+bare_queue_port_t *
+bare_queue_open_thread(bare_queue_t *queue, bare_queue_signal_cb on_signal) {
+  queue->on_signal_thread = on_signal;
+  queue->thread_open = true;
+
+  return &queue->thread_port;
+}
+
+int
+bare_queue_write(bare_queue_port_t *port, const void *data, size_t len) {
+  bare_queue_t *queue = port->queue;
+
+  if (len == 0) return 0;
+
+  bare_queue_ring_t *ring = port->is_uv ? &queue->to_thread : &queue->to_uv;
+
+  uv_mutex_lock(&queue->lock);
+
+  bool peer_closed = port->is_uv ? queue->thread_closed : queue->uv_closed;
+
+  if (peer_closed) {
+    uv_mutex_unlock(&queue->lock);
+    return bare_queue_closed;
+  }
+
+  void *base = malloc(len);
+  memcpy(base, data, len);
+
+  if (!bare_queue__ring_push(ring, base, len)) {
+    uv_mutex_unlock(&queue->lock);
+    free(base);
+    return bare_queue_would_block;
+  }
+
+  uv_mutex_unlock(&queue->lock);
+
+  if (port->is_uv) bare_queue__signal_thread(queue);
+  else bare_queue__signal_uv(queue);
+
+  return (int) len;
+}
+
+int
+bare_queue_read(bare_queue_port_t *port, void **data, size_t *len) {
+  bare_queue_t *queue = port->queue;
+
+  bare_queue_ring_t *ring = port->is_uv ? &queue->to_uv : &queue->to_thread;
+
+  uv_mutex_lock(&queue->lock);
+
+  bare_queue_message_t message;
+
+  if (!bare_queue__ring_shift(ring, &message)) {
+    bool peer_closed = port->is_uv ? queue->thread_closed : queue->uv_closed;
+
+    uv_mutex_unlock(&queue->lock);
+
+    if (!peer_closed) return bare_queue_would_block;
+
+    free(port->held);
+    port->held = NULL;
+
+    *data = NULL;
+    *len = 0;
+
+    return bare_queue_ok;
+  }
+
+  uv_mutex_unlock(&queue->lock);
+
+  free(port->held);
+  port->held = message.base;
+
+  *data = message.base;
+  *len = message.len;
+
+  return bare_queue_ok;
+}
+
+void
+bare_queue_close(bare_queue_port_t *port) {
+  bare_queue_t *queue = port->queue;
+
+  uv_mutex_lock(&queue->lock);
+
+  if (port->is_uv) queue->uv_closed = true;
+  else queue->thread_closed = true;
+
+  uv_mutex_unlock(&queue->lock);
+
+  if (port->is_uv) bare_queue__signal_thread(queue);
+  else bare_queue__signal_uv(queue);
+}
+
+uv_handle_t *
+bare_queue_uv_handle(bare_queue_t *queue) {
+  return (uv_handle_t *) &queue->async;
+}
+
+static void
+bare_queue__free(bare_queue_t *queue) {
+  bare_queue_message_t message;
+
+  while (bare_queue__ring_shift(&queue->to_uv, &message)) free(message.base);
+  while (bare_queue__ring_shift(&queue->to_thread, &message)) free(message.base);
+
+  free(queue->uv_port.held);
+  free(queue->thread_port.held);
+
+  uv_mutex_destroy(&queue->lock);
+
+  if (queue->on_close) queue->on_close(queue);
+}
+
+static void
+bare_queue__on_close(uv_handle_t *handle) {
+  bare_queue__free((bare_queue_t *) handle->data);
+}
+
+void
+bare_queue_destroy(bare_queue_t *queue, void (*on_close)(bare_queue_t *queue)) {
+  queue->on_close = on_close;
+
+  if (queue->uv_open) uv_close((uv_handle_t *) &queue->async, bare_queue__on_close);
+  else bare_queue__free(queue);
+}

--- a/shared/queue.c
+++ b/shared/queue.c
@@ -141,13 +141,16 @@ bare_queue_read(bare_queue_port_t *port, void **data, size_t *len) {
 
   uv_mutex_lock(&queue->lock);
 
+  bool was_full = ((ring->head + 1) & BARE_QUEUE_MASK) == ring->tail;
+
   bare_queue_message_t message;
+  bool shifted = bare_queue__ring_shift(ring, &message);
 
-  if (!bare_queue__ring_shift(ring, &message)) {
-    bool peer_closed = port->is_uv ? queue->thread_closed : queue->uv_closed;
+  bool peer_closed = port->is_uv ? queue->thread_closed : queue->uv_closed;
 
-    uv_mutex_unlock(&queue->lock);
+  uv_mutex_unlock(&queue->lock);
 
+  if (!shifted) {
     if (!peer_closed) return bare_queue_would_block;
 
     free(port->held);
@@ -159,7 +162,11 @@ bare_queue_read(bare_queue_port_t *port, void **data, size_t *len) {
     return bare_queue_ok;
   }
 
-  uv_mutex_unlock(&queue->lock);
+  // Draining a full ring lets the peer producer retry a blocked write.
+  if (was_full) {
+    if (port->is_uv) bare_queue__signal_thread(queue);
+    else bare_queue__signal_uv(queue);
+  }
 
   free(port->held);
   port->held = message.base;

--- a/shared/queue.c
+++ b/shared/queue.c
@@ -211,11 +211,6 @@ bare_queue_close(bare_queue_port_t *port) {
   else bare_queue__signal_uv(queue);
 }
 
-uv_handle_t *
-bare_queue_uv_handle(bare_queue_t *queue) {
-  return (uv_handle_t *) &queue->async;
-}
-
 static void
 bare_queue__free(bare_queue_t *queue) {
   bare_queue_message_t message;

--- a/shared/queue.h
+++ b/shared/queue.h
@@ -83,7 +83,8 @@ bare_queue_open_uv(bare_queue_t *queue, uv_loop_t *loop, bare_queue_recv_cb on_r
 // worklet thread, whenever this end's state changes: data to read, or space
 // freed so a blocked write can be retried. The host hops to its own run loop
 // and re-checks both. It may fire during this call if the worklet has already
-// queued data.
+// queued data, and must be safe to call concurrently: an open racing a
+// worklet-thread signal can invoke it from two threads at once.
 bare_queue_port_t *
 bare_queue_open_thread(bare_queue_t *queue, bare_queue_signal_cb on_signal);
 

--- a/shared/queue.h
+++ b/shared/queue.h
@@ -103,9 +103,6 @@ bare_queue_read(bare_queue_port_t *port, void **data, size_t *len);
 void
 bare_queue_close(bare_queue_port_t *port);
 
-uv_handle_t *
-bare_queue_uv_handle(bare_queue_t *queue);
-
 // Tears down the queue and frees any buffered messages. Must be called on the
 // worklet (uv) thread, and only once the host end is quiesced: after this call
 // neither port may be read, written, or closed from either thread. `on_close`

--- a/shared/queue.h
+++ b/shared/queue.h
@@ -71,14 +71,19 @@ struct bare_queue_s {
 void
 bare_queue_init(bare_queue_t *queue);
 
-// Opens the worklet (uv) end. `on_recv` fires on `loop` when the host has sent
-// something to drain.
+// Opens the worklet (uv) end. `on_recv` fires on `loop` whenever this end's
+// state changes: the host has sent data to read, or has drained a full ring so
+// a blocked write can be retried. Re-check both readability and writability on
+// each wake. It also fires once during this call if the host has already queued
+// data.
 bare_queue_port_t *
 bare_queue_open_uv(bare_queue_t *queue, uv_loop_t *loop, bare_queue_recv_cb on_recv);
 
 // Opens the host (native thread) end. `on_signal` is called, possibly from the
-// worklet thread, when the host should wake and drain; the host is responsible
-// for hopping to its own run loop.
+// worklet thread, whenever this end's state changes: data to read, or space
+// freed so a blocked write can be retried. The host hops to its own run loop
+// and re-checks both. It may fire during this call if the worklet has already
+// queued data.
 bare_queue_port_t *
 bare_queue_open_thread(bare_queue_t *queue, bare_queue_signal_cb on_signal);
 
@@ -100,6 +105,10 @@ bare_queue_close(bare_queue_port_t *port);
 uv_handle_t *
 bare_queue_uv_handle(bare_queue_t *queue);
 
+// Tears down the queue and frees any buffered messages. Must be called on the
+// worklet (uv) thread, and only once the host end is quiesced: after this call
+// neither port may be read, written, or closed from either thread. `on_close`
+// runs when teardown completes (from the uv loop when the uv end was opened).
 void
 bare_queue_destroy(bare_queue_t *queue, void (*on_close)(bare_queue_t *queue));
 

--- a/shared/queue.h
+++ b/shared/queue.h
@@ -1,0 +1,110 @@
+#ifndef BARE_KIT_QUEUE_H
+#define BARE_KIT_QUEUE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <uv.h>
+
+// A bidirectional in-process message queue between the worklet, which runs on a
+// libuv loop, and the host, which is a plain native thread. Each direction is an
+// independent bounded ring of owned byte messages guarded by a single mutex.
+// The worklet (uv) end is woken via a uv_async; the host end is woken via a
+// caller-provided signal callback, which is the only platform-specific concern.
+
+#define BARE_QUEUE_CAPACITY 1024 // Must be a power of two
+
+typedef struct bare_queue_s bare_queue_t;
+typedef struct bare_queue_port_s bare_queue_port_t;
+
+typedef void (*bare_queue_signal_cb)(bare_queue_port_t *port);
+typedef void (*bare_queue_recv_cb)(bare_queue_port_t *port);
+
+enum {
+  bare_queue_ok = 0,
+  bare_queue_would_block = -1,
+  bare_queue_closed = -2,
+};
+
+typedef struct {
+  void *base;
+  size_t len;
+} bare_queue_message_t;
+
+typedef struct {
+  bare_queue_message_t slots[BARE_QUEUE_CAPACITY];
+  int head; // Producer pushes here
+  int tail; // Consumer shifts from here
+} bare_queue_ring_t;
+
+struct bare_queue_port_s {
+  bare_queue_t *queue;
+  bool is_uv;
+  void *held; // Buffer handed to the last read, freed on the next read
+  void *data;
+};
+
+struct bare_queue_s {
+  uv_async_t async; // Wakes the uv side; also the handle closed on destroy
+  uv_mutex_t lock;
+
+  bare_queue_ring_t to_uv;     // Host -> worklet
+  bare_queue_ring_t to_thread; // Worklet -> host
+
+  bool uv_open;
+  bool thread_open;
+  bool uv_closed;
+  bool thread_closed;
+
+  bare_queue_signal_cb on_signal_thread;
+  bare_queue_recv_cb on_recv_uv;
+
+  bare_queue_port_t uv_port;
+  bare_queue_port_t thread_port;
+
+  void (*on_close)(bare_queue_t *queue);
+};
+
+void
+bare_queue_init(bare_queue_t *queue);
+
+// Opens the worklet (uv) end. `on_recv` fires on `loop` when the host has sent
+// something to drain.
+bare_queue_port_t *
+bare_queue_open_uv(bare_queue_t *queue, uv_loop_t *loop, bare_queue_recv_cb on_recv);
+
+// Opens the host (native thread) end. `on_signal` is called, possibly from the
+// worklet thread, when the host should wake and drain; the host is responsible
+// for hopping to its own run loop.
+bare_queue_port_t *
+bare_queue_open_thread(bare_queue_t *queue, bare_queue_signal_cb on_signal);
+
+// Copies `len` bytes to the peer. Returns `len`, `bare_queue_would_block` when
+// the ring is full, or `bare_queue_closed` when the peer has closed. A zero
+// length write is a no-op returning 0, so it is never mistaken for EOF.
+int
+bare_queue_write(bare_queue_port_t *port, const void *data, size_t len);
+
+// Hands back the next message, owned by the port until the following read.
+// Returns `bare_queue_ok` with `*len` set (0 meaning EOF once the peer closed),
+// or `bare_queue_would_block` when nothing is ready.
+int
+bare_queue_read(bare_queue_port_t *port, void **data, size_t *len);
+
+void
+bare_queue_close(bare_queue_port_t *port);
+
+uv_handle_t *
+bare_queue_uv_handle(bare_queue_t *queue);
+
+void
+bare_queue_destroy(bare_queue_t *queue, void (*on_close)(bare_queue_t *queue));
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // BARE_KIT_QUEUE_H

--- a/test/shared/CMakeLists.txt
+++ b/test/shared/CMakeLists.txt
@@ -1,4 +1,5 @@
 list(APPEND tests
+  queue
   worklet-assets
   worklet-destroy-before-start
   worklet-ipc

--- a/test/shared/queue.c
+++ b/test/shared/queue.c
@@ -23,6 +23,43 @@ main() {
 
   uv_loop_t *loop = uv_default_loop();
 
+  // Catch-up on open: data queued before the consumer opens still wakes it.
+  {
+    bare_queue_t q;
+    bare_queue_init(&q);
+
+    // Host writes, then the worklet opens.
+    bare_queue_port_t *producer = bare_queue_open_thread(&q, on_signal);
+    assert(bare_queue_write(producer, "early", 5) == 5);
+
+    uv_received = 0;
+    bare_queue_open_uv(&q, loop, on_recv_uv);
+    err = uv_run(loop, UV_RUN_NOWAIT);
+    assert(err >= 0);
+    assert(uv_received == 1);
+
+    bare_queue_destroy(&q, NULL);
+    err = uv_run(loop, UV_RUN_DEFAULT);
+    assert(err == 0);
+  }
+
+  {
+    bare_queue_t q;
+    bare_queue_init(&q);
+
+    // Worklet writes, then the host opens: it is signalled during open.
+    bare_queue_port_t *producer = bare_queue_open_uv(&q, loop, on_recv_uv);
+    assert(bare_queue_write(producer, "early", 5) == 5);
+
+    int before = signaled;
+    bare_queue_open_thread(&q, on_signal);
+    assert(signaled == before + 1);
+
+    bare_queue_destroy(&q, NULL);
+    err = uv_run(loop, UV_RUN_DEFAULT);
+    assert(err == 0);
+  }
+
   bare_queue_t queue;
   bare_queue_init(&queue);
 

--- a/test/shared/queue.c
+++ b/test/shared/queue.c
@@ -1,0 +1,89 @@
+#include <assert.h>
+#include <string.h>
+#include <uv.h>
+
+#include "../../shared/queue.h"
+
+static int signaled = 0;
+static int uv_received = 0;
+
+static void
+on_signal(bare_queue_port_t *port) {
+  signaled++;
+}
+
+static void
+on_recv_uv(bare_queue_port_t *port) {
+  uv_received++;
+}
+
+int
+main() {
+  int err;
+
+  uv_loop_t *loop = uv_default_loop();
+
+  bare_queue_t queue;
+  bare_queue_init(&queue);
+
+  bare_queue_port_t *uv = bare_queue_open_uv(&queue, loop, on_recv_uv);
+  bare_queue_port_t *thread = bare_queue_open_thread(&queue, on_signal);
+
+  void *data;
+  size_t len;
+
+  // Empty reads block on both ends.
+  assert(bare_queue_read(uv, &data, &len) == bare_queue_would_block);
+  assert(bare_queue_read(thread, &data, &len) == bare_queue_would_block);
+
+  // Host -> worklet.
+  assert(bare_queue_write(thread, "ping", 4) == 4);
+  assert(bare_queue_read(uv, &data, &len) == bare_queue_ok);
+  assert(len == 4 && memcmp(data, "ping", 4) == 0);
+  assert(bare_queue_read(uv, &data, &len) == bare_queue_would_block);
+
+  // Worklet -> host, and the host is signalled.
+  int before = signaled;
+  assert(bare_queue_write(uv, "pong", 4) == 4);
+  assert(signaled == before + 1);
+  assert(bare_queue_read(thread, &data, &len) == bare_queue_ok);
+  assert(len == 4 && memcmp(data, "pong", 4) == 0);
+
+  // A host write wakes the worklet loop.
+  uv_received = 0;
+  assert(bare_queue_write(thread, "z", 1) == 1);
+  err = uv_run(loop, UV_RUN_NOWAIT);
+  assert(err >= 0);
+  assert(uv_received == 1);
+  assert(bare_queue_read(uv, &data, &len) == bare_queue_ok && len == 1);
+
+  // Backpressure: fill the ring, then the next write blocks.
+  int n = 0;
+  while (bare_queue_write(uv, "x", 1) == 1) n++;
+  assert(n == BARE_QUEUE_CAPACITY - 1);
+  assert(bare_queue_write(uv, "x", 1) == bare_queue_would_block);
+  while (bare_queue_read(thread, &data, &len) == bare_queue_ok && len > 0) n--;
+  assert(n == 0);
+
+  // Zero-length writes never enqueue, so they cannot be read as EOF.
+  assert(bare_queue_write(uv, "", 0) == 0);
+  assert(bare_queue_read(thread, &data, &len) == bare_queue_would_block);
+
+  // Closing one end surfaces EOF on the other, and further writes are rejected.
+  bare_queue_close(uv);
+  assert(bare_queue_read(thread, &data, &len) == bare_queue_ok && len == 0);
+  assert(bare_queue_write(thread, "late", 4) == bare_queue_closed);
+
+  bare_queue_close(thread);
+  assert(bare_queue_read(uv, &data, &len) == bare_queue_ok && len == 0);
+
+  bare_queue_destroy(&queue, NULL);
+
+  err = uv_run(loop, UV_RUN_DEFAULT);
+  assert(err == 0);
+
+  err = uv_loop_close(loop);
+  assert(err == 0);
+
+  return 0;
+}

--- a/test/shared/queue.c
+++ b/test/shared/queue.c
@@ -62,6 +62,15 @@ main() {
   while (bare_queue_write(uv, "x", 1) == 1) n++;
   assert(n == BARE_QUEUE_CAPACITY - 1);
   assert(bare_queue_write(uv, "x", 1) == bare_queue_would_block);
+
+  // Draining the full ring wakes the worklet so it can retry the blocked write.
+  uv_received = 0;
+  assert(bare_queue_read(thread, &data, &len) == bare_queue_ok && len == 1);
+  n--;
+  err = uv_run(loop, UV_RUN_NOWAIT);
+  assert(err >= 0);
+  assert(uv_received == 1);
+
   while (bare_queue_read(thread, &data, &len) == bare_queue_ok && len > 0) n--;
   assert(n == 0);
 


### PR DESCRIPTION
Part 1 of replacing bare-kit's pipe-based worklet<->host IPC with an in-process queue (context: #92).

Bare Kit is entirely in-process (worklets are threads), so pipes and sockets are the wrong tool and are the root of the EOF-on-exit and win32 problems tracked in #92. This adds the transport that will replace them: a small mutex-guarded bidirectional message queue between the worklet, which runs on a libuv loop, and the host, which is a plain native thread.

- Two bounded rings of owned byte messages, one per direction.
- The worklet end is woken via a `uv_async`; the host end via a caller-provided signal callback, which is the only platform-specific concern.
- Close surfaces as EOF (`read` returns length 0); writes give real backpressure (`would_block`), and draining a full ring wakes the peer to retry.

Standalone and unit-tested here; not yet wired into the IPC path. The transport swap (worklet.c + worklet.js + host `bare_ipc`, deleting the pipe `ipc.c` files) follows in a second PR.

Opening as a draft to get eyes on the queue design before I build the rewiring on top of it.
