### PR TITLE
Publish win32 prebuilds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -147,7 +147,6 @@ jobs:
       - run: npm install
       - run: bare-make generate --platform ${{ matrix.platform }} --arch ${{ matrix.arch }} --with-debug-symbols
       - run: bare-make build
-      # Both files: consumers need the import library to link against the DLL.
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.platform }}-${{ matrix.arch }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -124,12 +124,43 @@ jobs:
         with:
           name: ${{ matrix.platform }}-${{ matrix.arch }}
           path: build/linux/*.so
+  windows:
+    strategy:
+      matrix:
+        include:
+          - os: windows-2022
+            platform: win32
+            arch: x64
+          - os: windows-11-arm
+            platform: win32
+            arch: arm64
+    runs-on: ${{ matrix.os }}
+    name: Build / ${{ matrix.platform }}-${{ matrix.arch }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+      - run: choco install llvm --version 20.1.8 --force
+      - run: choco install nasm
+      - run: npm install --global bare-make
+      - run: npm install
+      - run: bare-make generate --platform ${{ matrix.platform }} --arch ${{ matrix.arch }} --with-debug-symbols
+      - run: bare-make build
+      # Both files: consumers need the import library to link against the DLL.
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ${{ matrix.platform }}-${{ matrix.arch }}
+          path: |
+            build/win32/bare-kit.dll
+            build/win32/bare-kit.lib
   merge:
     runs-on: macos-latest
     needs:
       - apple
       - android
       - linux
+      - windows
     name: Merge
     steps:
       - uses: actions/checkout@v6
@@ -154,6 +185,10 @@ jobs:
             prebuilds/android/bare-kit
             prebuilds/linux/x64/libbare-kit.so
             prebuilds/linux/arm64/libbare-kit.so
+            prebuilds/win32/x64/bare-kit.dll
+            prebuilds/win32/x64/bare-kit.lib
+            prebuilds/win32/arm64/bare-kit.dll
+            prebuilds/win32/arm64/bare-kit.lib
           retention-days: 5
   publish:
     runs-on: ubuntu-latest

--- a/prebuilds/Makefile
+++ b/prebuilds/Makefile
@@ -25,7 +25,11 @@ all: \
 	ios-javascriptcore/BareKit.xcframework \
 	android/bare-kit \
 	linux/x64/libbare-kit.so \
-	linux/arm64/libbare-kit.so
+	linux/arm64/libbare-kit.so \
+	win32/x64/bare-kit.dll \
+	win32/x64/bare-kit.lib \
+	win32/arm64/bare-kit.dll \
+	win32/arm64/bare-kit.lib
 
 apple/BareKit.xcframework: \
 	darwin/BareKit.framework \
@@ -74,5 +78,13 @@ ios-simulator-javascriptcore/BareKit.framework: \
 	ios-x64-simulator-javascriptcore/BareKit.framework
 
 linux/%/libbare-kit.so: linux-%/libbare-kit.so
+	mkdir -p $(dir $@)
+	cp -a $< $@
+
+win32/%/bare-kit.dll: win32-%/bare-kit.dll
+	mkdir -p $(dir $@)
+	cp -a $< $@
+
+win32/%/bare-kit.lib: win32-%/bare-kit.lib
 	mkdir -p $(dir $@)
 	cp -a $< $@


### PR DESCRIPTION
win32 is already built and tested in `integrate.yml` on both x64 and arm64, but `publish.yml` doesn't ship it, so there's no Windows prebuild to consume. This adds the publishing half only - no build changes.

Notes:

- Ships **both** `bare-kit.dll` and `bare-kit.lib`. No platform in the manifest currently ships an import library, so it's easy to miss, but consumers can't link against the DLL without it.
- The `windows` job mirrors the `linux` one, with the toolchain steps taken from `integrate.yml`'s `windows` job.
- Artifact paths (`build/win32/bare-kit.dll`, `build/win32/bare-kit.lib`) confirmed against a local `bare-make generate && build` on win32-arm64 - 41.4 MB and 1.4 MB respectively. Worth checking, since a mismatched path uploads an empty artifact silently.
- Makefile rules dry-run against a simulated artifact layout; prettier and lunte pass.

Motivation is [bare-windows](https://github.com/holepunchto/bare-windows), which needs a win32 prebuild to link the way bare-linux links the `.so`. Not urgent for us - it builds bare-kit from source in the meantime.

One thing I noticed but didn't touch: `setup-llvm` and the choco line here install the x86_64 LLVM regardless of runner architecture. It doesn't break the arm64 leg, so the runner image must be supplying a native clang that wins on PATH - just flagging it in case that image ever changes.
