### PR TITLE
Link bare_worklet privately into bare_kit on win32

### DIFF
--- a/win32/CMakeLists.txt
+++ b/win32/CMakeLists.txt
@@ -17,6 +17,6 @@ target_sources(
 
 target_link_libraries(
   bare_kit
-  PUBLIC
+  PRIVATE
     bare_worklet
 )


### PR DESCRIPTION
`bare_kit` is a shared library, so `bare_worklet` is an implementation detail and shouldn't be in its link interface. Right now it's PUBLIC, and `bare_worklet` carries `INTERFACE $<LINK_LIBRARY:WHOLE_ARCHIVE,bare_static>` - so anything that builds bare-kit from source and links the `bare_kit` target gets the whole static runtime *and* the DLL's import library, and the link dies in ~700 duplicate symbols:

```
lld-link: error: duplicate symbol: js_create_int32
>>> defined at libjs.lib(js.cc.obj)
>>> defined at bare-kit.lib(bare-kit.dll)
```

Found this in bare-windows, which fetches bare-kit as a subproject because there's no win32 release to consume yet. The prebuilt-consuming hosts never see it - they link an IMPORTED target, which has no interface to inherit.

PRIVATE still links bare_worklet (and, through it, the whole-archive bare_static) into the DLL itself; it only stops the requirement propagating to consumers. I checked that on win32-arm64: bare-kit.dll comes out the same size as before (41,411,072 bytes), still exports the full runtime surface - 778 plain C symbols including `uv_queue_work`, plus the mangled C++ ones - and a host linking it boots a worklet, loads stock prebuilt addons and runs Hyperswarm end to end. The test suite is unaffected either way, since `test/shared` links `bare_worklet` directly rather than `bare_kit`.
