### PR TITLE
v2.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(cmake-fetch REQUIRED PATHS node_modules/cmake-fetch)
 find_package(cmake-napi REQUIRED PATHS node_modules/cmake-napi)
 find_package(cmake-java REQUIRED PATHS node_modules/cmake-java)
 
-project(bare_kit LANGUAGES C CXX VERSION 2.3.0)
+project(bare_kit LANGUAGES C CXX VERSION 2.4.0)
 
 include(overrides.cmake)
 


### PR DESCRIPTION
Version bump so we can tag a release that ships win32 prebuilds - the publish job added in #95 has never actually run, since the last tag predates it.

Minor rather than patch because of what's accumulated since v2.3.0: #88 changes behaviour (the worklet closes `Bare.IPC` on exit so the host reads EOF), #86 and #89 add EOF signalling on Apple and Android, and #93 adds the in-process queue primitive. Plus #95 (win32 prebuilds) and #96 (linking `bare_worklet` privately on win32, so from-source consumers don't collide with the import library).

Not included: #92 and #94 are still in review, so win32 still has no IPC end-of-stream in this release.
