### PR TITLE
Bump bare to 1.31.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(APPLE)
   enable_language(OBJC)
 endif()
 
-fetch_package("github:holepunchto/bare@1.29.4")
+fetch_package("github:holepunchto/bare@1.31.1")
 
 add_subdirectory(shared)
 


### PR DESCRIPTION
Moves the `bare` pin from 1.29.4 to 1.31.1, mainly to pick up holepunchto/bare#178 - without it the win32 publish job can't link, since it builds RelWithDebInfo and every CRT symbol comes out undefined. That's what broke the v2.4.0 publish.

It's 24 commits of bare, though, not just the build fix, and a few of them touch the paths bare-kit leans on: #172 (`new Addon(url)`, deprecating the existing addon APIs), #171 (structured errors for addon and module loading), #156 (isolated module caches), #155 (TypeScript modules), plus several dependency updates that move the builtin module versions.

So this wants more than a green build. I'm running the bare-windows host against this branch to check the thing CI here doesn't cover: stock prebuilt addons still resolving through the delay-load hook, and the builtin versions still agreeing with what `bare-link` emits - a mismatch there shows up as `ADDON_NOT_FOUND` at worklet startup rather than as a build failure. Will report back before this is tagged.
