### PR TITLE
v2.4.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(cmake-fetch REQUIRED PATHS node_modules/cmake-fetch)
 find_package(cmake-napi REQUIRED PATHS node_modules/cmake-napi)
 find_package(cmake-java REQUIRED PATHS node_modules/cmake-java)
 
-project(bare_kit LANGUAGES C CXX VERSION 2.4.0)
+project(bare_kit LANGUAGES C CXX VERSION 2.4.1)
 
 include(overrides.cmake)
 


### PR DESCRIPTION
Release to get win32 prebuilds published. v2.4.0 tagged but never published: the windows job builds RelWithDebInfo, which couldn't link until holepunchto/bare#178, now picked up via #98.

Tag pushed alongside this PR per the release flow, so it merges only once publishing has succeeded.
