### PR TITLE
Bump bare to 1.31.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(APPLE)
   enable_language(OBJC)
 endif()
 
-fetch_package("github:holepunchto/bare@1.31.1")
+fetch_package("github:holepunchto/bare@1.31.2")
 
 add_subdirectory(shared)
 


### PR DESCRIPTION
Picks up holepunchto/bare#181, which declares the libuv exports in a `.def` rather than leaving them to `dllexport` annotations in the prebuilt objects.

Nothing observable changes: bare-kit.dll already exports those 318 `uv_*` symbols, `uv_queue_work` among them, which is what stock addons delay-import. The difference is that tightening bare-kit's exports or changing how libuv is built would now fail at link time instead of silently breaking addon loading at runtime.

Only bare moves, 1.31.1 to 1.31.2.
