### PR TITLE
Ship the export forwarders a host needs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -153,6 +153,7 @@ jobs:
           path: |
             build/win32/bare-kit.dll
             build/win32/bare-kit.lib
+            build/win32/bare-kit.def
   merge:
     runs-on: macos-latest
     needs:
@@ -186,8 +187,10 @@ jobs:
             prebuilds/linux/arm64/libbare-kit.so
             prebuilds/win32/x64/bare-kit.dll
             prebuilds/win32/x64/bare-kit.lib
+            prebuilds/win32/x64/bare-kit.def
             prebuilds/win32/arm64/bare-kit.dll
             prebuilds/win32/arm64/bare-kit.lib
+            prebuilds/win32/arm64/bare-kit.def
           retention-days: 5
   publish:
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(APPLE)
   enable_language(OBJC)
 endif()
 
-fetch_package("github:holepunchto/bare@1.31.2")
+fetch_package("github:holepunchto/bare@1.31.2" SOURCE_DIR bare)
 
 add_subdirectory(shared)
 

--- a/win32/CMakeLists.txt
+++ b/win32/CMakeLists.txt
@@ -20,3 +20,32 @@ target_link_libraries(
   PRIVATE
     bare_worklet
 )
+
+# A prebuilt addon delay-loads `bare.dll` and resolves it against the host
+# executable, so a host embedding the runtime here has to re-export these
+# symbols for any addon to load. Ship the forwarders next to the library so that
+# a host passes `/DEF:` at this file instead of deriving the list itself.
+set(exports
+  "${bare}/src/bare.def"
+  "${bare}/src/js.def"
+  "${bare}/src/napi.def"
+  "${bare}/src/uv.def"
+  "${CMAKE_CURRENT_LIST_DIR}/ipc.def"
+  "${CMAKE_CURRENT_LIST_DIR}/worklet.def"
+)
+
+set(forwarders "EXPORTS\n")
+
+foreach(export ${exports})
+  file(STRINGS "${export}" symbols)
+
+  foreach(symbol ${symbols})
+    string(STRIP "${symbol}" symbol)
+
+    if(symbol MATCHES "^[A-Za-z_][A-Za-z0-9_]*$" AND NOT symbol STREQUAL "EXPORTS")
+      string(APPEND forwarders "\t${symbol} = bare-kit.${symbol}\n")
+    endif()
+  endforeach()
+endforeach()
+
+file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/bare-kit.def" CONTENT "${forwarders}")


### PR DESCRIPTION
A prebuilt addon delay-loads `bare.dll` and resolves it against the host executable, so a host that embeds the runtime here has to re-export bare-kit's symbols or no addon loads. Today the host has to work that list out for itself, which meant reading the shipped DLL's export table - the thing you objected to in bare-windows#7.

bare-kit knows the ABI it exposes: it's the `.def` files it already links, now that holepunchto/bare#181 declares the libuv part too. So generate the forwarders from those and ship them next to the DLL and import library. A host then passes `/DEF:` at the file and derives nothing.

Checked the declaration is complete before relying on it: of the 812 C symbols the shipped DLL exports, 784 are declared and 0 declared symbols are missing, so the generated `.def` links. The 28 undeclared ones are the `bare_register_module_<builtin>_<hash>_` hooks plus `CrashForExceptionInNonABICompliantCodeRange` - nothing an addon imports.

Verified on win32-arm64 end to end: bare-windows built against the generated file exports 784 forwarders, loads stock prebuilt addons, and pairs with bare-macos over the DHT.

Stacked on #100, since the `uv_*` half of the ABI only exists from bare 1.31.2.
