### PR TITLE
v2.4.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ find_package(cmake-fetch REQUIRED PATHS node_modules/cmake-fetch)
 find_package(cmake-napi REQUIRED PATHS node_modules/cmake-napi)
 find_package(cmake-java REQUIRED PATHS node_modules/cmake-java)
 
-project(bare_kit LANGUAGES C CXX VERSION 2.4.1)
+project(bare_kit LANGUAGES C CXX VERSION 2.4.2)
 
 include(overrides.cmake)
 


### PR DESCRIPTION
Release so hosts can consume the export forwarders from #101, which needs the ABI declaration from #100.

Tag pushed alongside this PR per the release flow, so it merges once publishing has succeeded.
