### PR TITLE
Copy the win32 forwarders into the prebuilds

### DIFF
--- a/prebuilds/Makefile
+++ b/prebuilds/Makefile
@@ -28,8 +28,10 @@ all: \
 	linux/arm64/libbare-kit.so \
 	win32/x64/bare-kit.dll \
 	win32/x64/bare-kit.lib \
+	win32/x64/bare-kit.def \
 	win32/arm64/bare-kit.dll \
-	win32/arm64/bare-kit.lib
+	win32/arm64/bare-kit.lib \
+	win32/arm64/bare-kit.def
 
 apple/BareKit.xcframework: \
 	darwin/BareKit.framework \
@@ -86,5 +88,9 @@ win32/%/bare-kit.dll: win32-%/bare-kit.dll
 	cp -a $< $@
 
 win32/%/bare-kit.lib: win32-%/bare-kit.lib
+	mkdir -p $(dir $@)
+	cp -a $< $@
+
+win32/%/bare-kit.def: win32-%/bare-kit.def
 	mkdir -p $(dir $@)
 	cp -a $< $@


### PR DESCRIPTION
v2.4.2 shipped without the forwarders from #101. The win32 jobs did upload `bare-kit.def` - it is in the artifact - but the merge step assembles the release with `prebuilds/Makefile`, and I only listed the file in `publish.yml`, not there. So the merge copied the dll and lib and silently skipped the def, and bare-windows#7 fails on a release that looks complete.

Adds the two paths to `all` and the copy rule they need. Dry-ran it against a simulated artifact layout; both arches copy.

This needs a release to be of any use, so v2.4.3 after it.
