### PR TITLE
Signal the queue's peer under its lock

### DIFF
--- a/shared/queue.c
+++ b/shared/queue.c
@@ -36,6 +36,9 @@ bare_queue__signal_uv(bare_queue_t *queue) {
   if (queue->uv_open) uv_async_send(&queue->async);
 }
 
+// Chosen and called with the lock held, so a host that retires its end cannot
+// free what the callback touches in between. The callback may therefore only
+// wake the host's run loop - it must never re-enter the queue.
 static void
 bare_queue__signal_thread(bare_queue_t *queue) {
   if (queue->thread_open && queue->on_signal_thread) queue->on_signal_thread(&queue->thread_port);
@@ -86,12 +89,17 @@ bare_queue_open_uv(bare_queue_t *queue, uv_loop_t *loop, bare_queue_recv_cb on_r
   assert(err == 0);
 
   queue->async.data = queue;
+
+  // Published under the lock, because the peer reads them under it: an open can
+  // race a signal from the other thread.
+  uv_mutex_lock(&queue->lock);
+
   queue->on_recv_uv = on_recv;
   queue->uv_open = true;
 
   // Catch up on anything the host queued before we opened.
-  uv_mutex_lock(&queue->lock);
   bool pending = queue->to_uv.head != queue->to_uv.tail;
+
   uv_mutex_unlock(&queue->lock);
 
   if (pending) uv_async_send(&queue->async);
@@ -101,15 +109,15 @@ bare_queue_open_uv(bare_queue_t *queue, uv_loop_t *loop, bare_queue_recv_cb on_r
 
 bare_queue_port_t *
 bare_queue_open_thread(bare_queue_t *queue, bare_queue_signal_cb on_signal) {
+  uv_mutex_lock(&queue->lock);
+
   queue->on_signal_thread = on_signal;
   queue->thread_open = true;
 
   // Catch up on anything the worklet queued before we opened.
-  uv_mutex_lock(&queue->lock);
-  bool pending = queue->to_thread.head != queue->to_thread.tail;
-  uv_mutex_unlock(&queue->lock);
+  if (queue->to_thread.head != queue->to_thread.tail) bare_queue__signal_thread(queue);
 
-  if (pending && on_signal) on_signal(&queue->thread_port);
+  uv_mutex_unlock(&queue->lock);
 
   return &queue->thread_port;
 }
@@ -144,10 +152,10 @@ bare_queue_write(bare_queue_port_t *port, const void *data, size_t len) {
     return bare_queue_would_block;
   }
 
-  uv_mutex_unlock(&queue->lock);
-
   if (port->is_uv) bare_queue__signal_thread(queue);
   else bare_queue__signal_uv(queue);
+
+  uv_mutex_unlock(&queue->lock);
 
   return (int) len;
 }
@@ -167,6 +175,12 @@ bare_queue_read(bare_queue_port_t *port, void **data, size_t *len) {
 
   bool peer_closed = port->is_uv ? queue->thread_closed : queue->uv_closed;
 
+  // Draining a full ring lets the peer producer retry a blocked write.
+  if (shifted && was_full) {
+    if (port->is_uv) bare_queue__signal_thread(queue);
+    else bare_queue__signal_uv(queue);
+  }
+
   uv_mutex_unlock(&queue->lock);
 
   if (!shifted) {
@@ -179,12 +193,6 @@ bare_queue_read(bare_queue_port_t *port, void **data, size_t *len) {
     *len = 0;
 
     return bare_queue_ok;
-  }
-
-  // Draining a full ring lets the peer producer retry a blocked write.
-  if (was_full) {
-    if (port->is_uv) bare_queue__signal_thread(queue);
-    else bare_queue__signal_uv(queue);
   }
 
   free(port->held);
@@ -205,18 +213,20 @@ bare_queue_close(bare_queue_port_t *port) {
   if (port->is_uv) queue->uv_closed = true;
   else queue->thread_closed = true;
 
-  uv_mutex_unlock(&queue->lock);
-
   if (port->is_uv) bare_queue__signal_thread(queue);
   else bare_queue__signal_uv(queue);
+
+  uv_mutex_unlock(&queue->lock);
 }
 
 static void
 bare_queue__free(bare_queue_t *queue) {
   bare_queue_message_t message;
 
-  while (bare_queue__ring_shift(&queue->to_uv, &message)) free(message.base);
-  while (bare_queue__ring_shift(&queue->to_thread, &message)) free(message.base);
+  while (bare_queue__ring_shift(&queue->to_uv, &message))
+    free(message.base);
+  while (bare_queue__ring_shift(&queue->to_thread, &message))
+    free(message.base);
 
   free(queue->uv_port.held);
   free(queue->thread_port.held);

--- a/test/shared/CMakeLists.txt
+++ b/test/shared/CMakeLists.txt
@@ -1,5 +1,6 @@
 list(APPEND tests
   queue
+  queue-signal-lock
   worklet-assets
   worklet-destroy-before-start
   worklet-ipc

--- a/test/shared/queue-signal-lock.c
+++ b/test/shared/queue-signal-lock.c
@@ -1,0 +1,86 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <uv.h>
+
+#include "../../shared/queue.h"
+
+// A signal callback must run with the queue's lock held. Without that the peer
+// can retire its end - and free whatever the callback touches - between the
+// queue deciding to call it and the call happening.
+//
+// The callback parks for a while and this asserts the lock cannot be taken for
+// as long as it is in there.
+
+static bare_queue_t queue;
+
+static uv_sem_t entered;
+static uv_loop_t loop;
+
+static bool locked_during_callback;
+
+static void
+on_signal(bare_queue_port_t *port) {
+  uv_sem_post(&entered);
+
+  // Long enough that a lock taken meanwhile is a real observation, not a race
+  // the assert happened to win.
+  uv_sleep(500);
+}
+
+static void
+on_recv_uv(bare_queue_port_t *port) {}
+
+static void
+on_thread(void *arg) {
+  bare_queue_port_t *uv = (bare_queue_port_t *) arg;
+
+  // Wakes the host end, which calls on_signal from this thread.
+  int written = bare_queue_write(uv, "x", 1);
+  assert(written == 1);
+}
+
+int
+main() {
+  int err;
+
+  err = uv_loop_init(&loop);
+  assert(err == 0);
+
+  err = uv_sem_init(&entered, 0);
+  assert(err == 0);
+
+  bare_queue_init(&queue);
+
+  bare_queue_port_t *uv = bare_queue_open_uv(&queue, &loop, on_recv_uv);
+  bare_queue_open_thread(&queue, on_signal);
+
+  uv_thread_t producer;
+  err = uv_thread_create(&producer, on_thread, (void *) uv);
+  assert(err == 0);
+
+  uv_sem_wait(&entered);
+
+  // The callback is running right now. Taking the lock must not be possible.
+  if (uv_mutex_trylock(&queue.lock) == 0) {
+    uv_mutex_unlock(&queue.lock);
+  } else {
+    locked_during_callback = true;
+  }
+
+  err = uv_thread_join(&producer);
+  assert(err == 0);
+
+  assert(locked_during_callback);
+
+  bare_queue_destroy(&queue, NULL);
+
+  err = uv_run(&loop, UV_RUN_DEFAULT);
+  assert(err == 0);
+
+  err = uv_loop_close(&loop);
+  assert(err == 0);
+
+  uv_sem_destroy(&entered);
+
+  return 0;
+}


### PR DESCRIPTION
The signal callback is picked outside the lock and invoked after it is released, so a peer that retires its end in that window still gets called. The open state is published outside the lock too, for fields the peer reads under it.

Both move under the lock. The consequence worth knowing is that the callback now runs with the lock held, so it may only wake a run loop - never re-enter the queue - which is what all three platform implementations do.

Split out of #94, where this was tangled up with the transport change. Nothing consumes the queue on main yet, so this stands on its own.