### PR TITLE
Give the queue an owner rather than a caller's storage

### DIFF
--- a/shared/queue.c
+++ b/shared/queue.c
@@ -33,15 +33,17 @@ bare_queue__ring_shift(bare_queue_ring_t *ring, bare_queue_message_t *message) {
 
 static void
 bare_queue__signal_uv(bare_queue_t *queue) {
-  if (queue->uv_open) uv_async_send(&queue->async);
+  // Never wake a peer that has closed its end; it may be tearing down.
+  if (queue->uv_open && !queue->uv_closed) uv_async_send(&queue->async);
 }
 
-// Chosen and called with the lock held, so a host that retires its end cannot
-// free what the callback touches in between. The callback may therefore only
-// wake the host's run loop - it must never re-enter the queue.
+// Called with the lock held, and it keeps it: `bare_queue_shutdown_thread` takes
+// the same lock to clear the callback, so the host cannot free what the callback
+// touches between the check here and the call. The callback may therefore only
+// wake the host's run loop - never re-enter the queue.
 static void
 bare_queue__signal_thread(bare_queue_t *queue) {
-  if (queue->thread_open && queue->on_signal_thread) queue->on_signal_thread(&queue->thread_port);
+  if (queue->thread_open && !queue->thread_closed && queue->on_signal_thread) queue->on_signal_thread(&queue->thread_port);
 }
 
 static void
@@ -51,9 +53,13 @@ bare_queue__on_wakeup_uv(uv_async_t *async) {
   if (queue->on_recv_uv) queue->on_recv_uv(&queue->uv_port);
 }
 
-void
-bare_queue_init(bare_queue_t *queue) {
+bare_queue_t *
+bare_queue_create(void) {
   int err;
+
+  bare_queue_t *queue = malloc(sizeof(bare_queue_t));
+
+  if (queue == NULL) return NULL;
 
   memset(&queue->to_uv, 0, sizeof(queue->to_uv));
   memset(&queue->to_thread, 0, sizeof(queue->to_thread));
@@ -65,7 +71,6 @@ bare_queue_init(bare_queue_t *queue) {
 
   queue->on_signal_thread = NULL;
   queue->on_recv_uv = NULL;
-  queue->on_close = NULL;
 
   queue->uv_port.queue = queue;
   queue->uv_port.is_uv = true;
@@ -79,6 +84,8 @@ bare_queue_init(bare_queue_t *queue) {
 
   err = uv_mutex_init(&queue->lock);
   assert(err == 0);
+
+  return queue;
 }
 
 bare_queue_port_t *
@@ -219,8 +226,41 @@ bare_queue_close(bare_queue_port_t *port) {
   uv_mutex_unlock(&queue->lock);
 }
 
-static void
-bare_queue__free(bare_queue_t *queue) {
+bool
+bare_queue_readable(bare_queue_port_t *port) {
+  bare_queue_t *queue = port->queue;
+
+  bare_queue_ring_t *ring = port->is_uv ? &queue->to_uv : &queue->to_thread;
+
+  uv_mutex_lock(&queue->lock);
+
+  bool peer_closed = port->is_uv ? queue->thread_closed : queue->uv_closed;
+  bool readable = ring->head != ring->tail || peer_closed;
+
+  uv_mutex_unlock(&queue->lock);
+
+  return readable;
+}
+
+bool
+bare_queue_writable(bare_queue_port_t *port) {
+  bare_queue_t *queue = port->queue;
+
+  bare_queue_ring_t *ring = port->is_uv ? &queue->to_thread : &queue->to_uv;
+
+  uv_mutex_lock(&queue->lock);
+
+  bool peer_closed = port->is_uv ? queue->thread_closed : queue->uv_closed;
+  bool full = ((ring->head + 1) & BARE_QUEUE_MASK) == ring->tail;
+  bool writable = !peer_closed && !full;
+
+  uv_mutex_unlock(&queue->lock);
+
+  return writable;
+}
+
+void
+bare_queue_destroy(bare_queue_t *queue) {
   bare_queue_message_t message;
 
   while (bare_queue__ring_shift(&queue->to_uv, &message))
@@ -233,18 +273,19 @@ bare_queue__free(bare_queue_t *queue) {
 
   uv_mutex_destroy(&queue->lock);
 
-  if (queue->on_close) queue->on_close(queue);
-}
-
-static void
-bare_queue__on_close(uv_handle_t *handle) {
-  bare_queue__free((bare_queue_t *) handle->data);
+  free(queue);
 }
 
 void
-bare_queue_destroy(bare_queue_t *queue, void (*on_close)(bare_queue_t *queue)) {
-  queue->on_close = on_close;
+bare_queue_shutdown_uv(bare_queue_t *queue) {
+  if (queue->uv_open) uv_close((uv_handle_t *) &queue->async, NULL);
+}
 
-  if (queue->uv_open) uv_close((uv_handle_t *) &queue->async, bare_queue__on_close);
-  else bare_queue__free(queue);
+void
+bare_queue_shutdown_thread(bare_queue_t *queue) {
+  uv_mutex_lock(&queue->lock);
+
+  queue->on_signal_thread = NULL;
+
+  uv_mutex_unlock(&queue->lock);
 }

--- a/shared/queue.h
+++ b/shared/queue.h
@@ -64,12 +64,20 @@ struct bare_queue_s {
 
   bare_queue_port_t uv_port;
   bare_queue_port_t thread_port;
-
-  void (*on_close)(bare_queue_t *queue);
 };
 
+// The worklet closes its end after it has parked, so by the ownership invariants
+// the queue belongs to the worklet, and cannot live in the host's storage: the
+// host is free to destroy its worklet the moment it has signalled it.
+//
+// Created on the host thread, handed to the worklet at start, and freed by
+// `bare_queue_destroy` on the worklet thread once its loop is done. A host that
+// never started a worklet frees it itself.
+bare_queue_t *
+bare_queue_create(void);
+
 void
-bare_queue_init(bare_queue_t *queue);
+bare_queue_destroy(bare_queue_t *queue);
 
 // Opens the worklet (uv) end. `on_recv` fires on `loop` whenever this end's
 // state changes: the host has sent data to read, or has drained a full ring so
@@ -103,12 +111,26 @@ bare_queue_read(bare_queue_port_t *port, void **data, size_t *len);
 void
 bare_queue_close(bare_queue_port_t *port);
 
-// Tears down the queue and frees any buffered messages. Must be called on the
-// worklet (uv) thread, and only once the host end is quiesced: after this call
-// neither port may be read, written, or closed from either thread. `on_close`
-// runs when teardown completes (from the uv loop when the uv end was opened).
+// Non-consuming status for a poller. `readable` is true when a read would not
+// return `bare_queue_would_block` (data buffered, or EOF once the peer closed);
+// `writable` is true when a write would not (space free and the peer open).
+bool
+bare_queue_readable(bare_queue_port_t *port);
+
+bool
+bare_queue_writable(bare_queue_port_t *port);
+
+// Retires the worklet (uv) end by closing its wakeup handle. Must be called on
+// the worklet thread, with the loop still to run so the close completes.
 void
-bare_queue_destroy(bare_queue_t *queue, void (*on_close)(bare_queue_t *queue));
+bare_queue_shutdown_uv(bare_queue_t *queue);
+
+// Retires the host end: after this the worklet will not call `on_signal` again,
+// so the host may free whatever that callback touches. Must be called before the
+// host signals its worklet to be destroyed, because afterwards the queue is the
+// worklet's alone.
+void
+bare_queue_shutdown_thread(bare_queue_t *queue);
 
 #ifdef __cplusplus
 }

--- a/test/shared/CMakeLists.txt
+++ b/test/shared/CMakeLists.txt
@@ -1,5 +1,6 @@
 list(APPEND tests
   queue
+  queue-threads
   worklet-assets
   worklet-destroy-before-start
   worklet-ipc

--- a/test/shared/queue-threads.c
+++ b/test/shared/queue-threads.c
@@ -1,0 +1,99 @@
+#include <assert.h>
+#include <stdatomic.h>
+#include <stdbool.h>
+#include <uv.h>
+
+#include "../../shared/queue.h"
+
+// Exercises the queue across a real thread boundary: the main thread produces
+// on the thread port while a uv thread consumes on the uv port. Verifies every
+// message arrives once, in order, through the mutex + async wakeup, that
+// backpressure holds under a full ring, and that close reaches the consumer as
+// EOF.
+
+#define MESSAGES 100000
+
+static bare_queue_t *queue;
+static uv_loop_t loop;
+static uv_sem_t opened;
+
+static int received = 0; // uv thread only
+
+static void
+on_recv_uv(bare_queue_port_t *port) {
+  void *data;
+  size_t len;
+
+  while (bare_queue_read(port, &data, &len) == bare_queue_ok) {
+    if (len == 0) {
+      // EOF: unref the async so the loop can drain and uv_run returns.
+      uv_unref((uv_handle_t *) &port->queue->async);
+      return;
+    }
+
+    assert(len == sizeof(int));
+    assert(*(int *) data == received);
+    received++;
+  }
+}
+
+static void
+on_thread(void *arg) {
+  bare_queue_open_uv(queue, &loop, on_recv_uv);
+
+  uv_sem_post(&opened);
+
+  int err = uv_run(&loop, UV_RUN_DEFAULT);
+  assert(err == 0);
+}
+
+int
+main() {
+  int err;
+
+  queue = bare_queue_create();
+
+  err = uv_loop_init(&loop);
+  assert(err == 0);
+
+  err = uv_sem_init(&opened, 0);
+  assert(err == 0);
+
+  bare_queue_port_t *thread = bare_queue_open_thread(queue, NULL);
+
+  uv_thread_t consumer;
+  err = uv_thread_create(&consumer, on_thread, NULL);
+  assert(err == 0);
+
+  uv_sem_wait(&opened);
+
+  for (int i = 0; i < MESSAGES;) {
+    int status = bare_queue_write(thread, &i, sizeof(int));
+
+    if (status == (int) sizeof(int)) i++;
+    else assert(status == bare_queue_would_block); // full ring: retry
+  }
+
+  bare_queue_close(thread);
+
+  err = uv_thread_join(&consumer);
+  assert(err == 0);
+
+  assert(received == MESSAGES);
+
+  // The consumer only unref'd the async; close it and pump once to finish.
+  bare_queue_shutdown_uv(queue);
+  bare_queue_shutdown_thread(queue);
+
+  err = uv_run(&loop, UV_RUN_DEFAULT);
+  assert(err == 0);
+
+  bare_queue_destroy(queue);
+
+  err = uv_loop_close(&loop);
+  assert(err == 0);
+
+  uv_sem_destroy(&opened);
+
+  return 0;
+}

--- a/test/shared/queue.c
+++ b/test/shared/queue.c
@@ -25,46 +25,70 @@ main() {
 
   // Catch-up on open: data queued before the consumer opens still wakes it.
   {
-    bare_queue_t q;
-    bare_queue_init(&q);
+    bare_queue_t *q = bare_queue_create();
 
     // Host writes, then the worklet opens.
-    bare_queue_port_t *producer = bare_queue_open_thread(&q, on_signal);
+    bare_queue_port_t *producer = bare_queue_open_thread(q, on_signal);
     assert(bare_queue_write(producer, "early", 5) == 5);
 
     uv_received = 0;
-    bare_queue_open_uv(&q, loop, on_recv_uv);
+    bare_queue_open_uv(q, loop, on_recv_uv);
     err = uv_run(loop, UV_RUN_NOWAIT);
     assert(err >= 0);
     assert(uv_received == 1);
 
-    bare_queue_destroy(&q, NULL);
+    bare_queue_shutdown_uv(q);
+    bare_queue_shutdown_thread(q);
     err = uv_run(loop, UV_RUN_DEFAULT);
     assert(err == 0);
+    bare_queue_destroy(q);
   }
 
   {
-    bare_queue_t q;
-    bare_queue_init(&q);
+    bare_queue_t *q = bare_queue_create();
 
     // Worklet writes, then the host opens: it is signalled during open.
-    bare_queue_port_t *producer = bare_queue_open_uv(&q, loop, on_recv_uv);
+    bare_queue_port_t *producer = bare_queue_open_uv(q, loop, on_recv_uv);
     assert(bare_queue_write(producer, "early", 5) == 5);
 
     int before = signaled;
-    bare_queue_open_thread(&q, on_signal);
+    bare_queue_open_thread(q, on_signal);
     assert(signaled == before + 1);
 
-    bare_queue_destroy(&q, NULL);
+    bare_queue_shutdown_uv(q);
+    bare_queue_shutdown_thread(q);
     err = uv_run(loop, UV_RUN_DEFAULT);
     assert(err == 0);
+    bare_queue_destroy(q);
   }
 
-  bare_queue_t queue;
-  bare_queue_init(&queue);
+  // Non-consuming poll status.
+  {
+    bare_queue_t *q = bare_queue_create();
+    bare_queue_port_t *u = bare_queue_open_uv(q, loop, on_recv_uv);
+    bare_queue_port_t *t = bare_queue_open_thread(q, on_signal);
 
-  bare_queue_port_t *uv = bare_queue_open_uv(&queue, loop, on_recv_uv);
-  bare_queue_port_t *thread = bare_queue_open_thread(&queue, on_signal);
+    assert(!bare_queue_readable(u) && bare_queue_writable(u));
+    assert(!bare_queue_readable(t) && bare_queue_writable(t));
+
+    assert(bare_queue_write(t, "x", 1) == 1);
+    assert(bare_queue_readable(u));
+
+    bare_queue_close(t);
+    assert(!bare_queue_writable(u)); // peer closed
+    assert(bare_queue_readable(u));  // buffered data, then EOF
+
+    bare_queue_shutdown_uv(q);
+    bare_queue_shutdown_thread(q);
+    err = uv_run(loop, UV_RUN_DEFAULT);
+    assert(err == 0);
+    bare_queue_destroy(q);
+  }
+
+  bare_queue_t *queue = bare_queue_create();
+
+  bare_queue_port_t *uv = bare_queue_open_uv(queue, loop, on_recv_uv);
+  bare_queue_port_t *thread = bare_queue_open_thread(queue, on_signal);
 
   void *data;
   size_t len;
@@ -96,7 +120,8 @@ main() {
 
   // Backpressure: fill the ring, then the next write blocks.
   int n = 0;
-  while (bare_queue_write(uv, "x", 1) == 1) n++;
+  while (bare_queue_write(uv, "x", 1) == 1)
+    n++;
   assert(n == BARE_QUEUE_CAPACITY - 1);
   assert(bare_queue_write(uv, "x", 1) == bare_queue_would_block);
 
@@ -108,7 +133,8 @@ main() {
   assert(err >= 0);
   assert(uv_received == 1);
 
-  while (bare_queue_read(thread, &data, &len) == bare_queue_ok && len > 0) n--;
+  while (bare_queue_read(thread, &data, &len) == bare_queue_ok && len > 0)
+    n--;
   assert(n == 0);
 
   // Zero-length writes never enqueue, so they cannot be read as EOF.
@@ -123,10 +149,13 @@ main() {
   bare_queue_close(thread);
   assert(bare_queue_read(uv, &data, &len) == bare_queue_ok && len == 0);
 
-  bare_queue_destroy(&queue, NULL);
+  bare_queue_shutdown_uv(queue);
+  bare_queue_shutdown_thread(queue);
 
   err = uv_run(loop, UV_RUN_DEFAULT);
   assert(err == 0);
+
+  bare_queue_destroy(queue);
 
   err = uv_loop_close(loop);
   assert(err == 0);


### PR DESCRIPTION
The worklet closes its end of the queue after it has parked, so by the invariants the queue must be owned by the worklet - and therefore cannot live in `bare_worklet_t`, which is the host's storage and may go away as soon as the host has signalled the worklet to be destroyed.

So: heap allocated, created by the host, handed over at start, freed by the worklet thread when its loop is done (or by the host when no worklet was ever started). `bare_queue_shutdown_uv` and `bare_queue_shutdown_thread` retire one end each, so whichever side goes first stops the other from reaching what it is about to free.

Nothing consumes the queue on main yet, so this changes an unused primitive and can be reviewed on its own. It is the ownership half of #94; the transport swap follows.

Stacked on #105.