### PR TITLE
Keep an IPC's worklet alive for as long as the IPC

### DIFF
--- a/android/src/main/java/to/holepunch/bare/kit/IPC.java
+++ b/android/src/main/java/to/holepunch/bare/kit/IPC.java
@@ -27,10 +27,16 @@ public class IPC implements Closeable {
 
   ByteBuffer handle;
 
+  // An IPC is opened on a worklet and is meaningless without it, so it must not
+  // outlive it. Held here to keep it reachable for as long as this is.
+  private final Worklet worklet;
+
   private PollCallback readable;
   private PollCallback writable;
 
   public IPC(Worklet worklet) {
+    this.worklet = worklet;
+
     handle = init(worklet.handle);
   }
 

--- a/apple/BareKit/BareKit.m
+++ b/apple/BareKit/BareKit.m
@@ -296,8 +296,9 @@ bare_ipc__on_poll(bare_ipc_poll_t *poll, int events) {
 }
 
 @implementation BareIPC {
-  // Strong: an IPC is opened on a worklet and is meaningless without it, so it
-  // must not outlive it. Holding it here is what orders the two deallocs.
+  // Retained: an IPC is opened on a worklet and is meaningless without it, so it
+  // must not outlive it. This file is manual reference counting, so the retain
+  // and the release below are what actually hold it.
   BareWorklet *_worklet;
 
   bare_ipc_t _ipc;
@@ -310,7 +311,7 @@ bare_ipc__on_poll(bare_ipc_poll_t *poll, int events) {
   if (self) {
     int err;
 
-    _worklet = worklet;
+    _worklet = [worklet retain];
 
     err = bare_ipc_init(&_ipc, &worklet->_worklet);
     assert(err == 0);
@@ -458,6 +459,12 @@ bare_ipc__on_poll(bare_ipc_poll_t *poll, int events) {
 - (void)close {
   bare_ipc_poll_destroy(&_poll);
   bare_ipc_destroy(&_ipc);
+}
+
+- (void)dealloc {
+  [_worklet release];
+
+  [super dealloc];
 }
 
 @end

--- a/apple/BareKit/BareKit.m
+++ b/apple/BareKit/BareKit.m
@@ -296,6 +296,10 @@ bare_ipc__on_poll(bare_ipc_poll_t *poll, int events) {
 }
 
 @implementation BareIPC {
+  // Strong: an IPC is opened on a worklet and is meaningless without it, so it
+  // must not outlive it. Holding it here is what orders the two deallocs.
+  BareWorklet *_worklet;
+
   bare_ipc_t _ipc;
   bare_ipc_poll_t _poll;
 }
@@ -305,6 +309,8 @@ bare_ipc__on_poll(bare_ipc_poll_t *poll, int events) {
 
   if (self) {
     int err;
+
+    _worklet = worklet;
 
     err = bare_ipc_init(&_ipc, &worklet->_worklet);
     assert(err == 0);

--- a/test/apple/CMakeLists.txt
+++ b/test/apple/CMakeLists.txt
@@ -1,4 +1,5 @@
 list(APPEND tests
+  ipc-retains-worklet
   worklet-ipc
   worklet-ipc-eof
   worklet-ipc-large-write

--- a/test/apple/ipc-retains-worklet.m
+++ b/test/apple/ipc-retains-worklet.m
@@ -1,0 +1,33 @@
+#import <BareKit/BareKit.h>
+#import <Foundation/Foundation.h>
+#import <assert.h>
+
+// An IPC is opened on a worklet and is meaningless without it, so it must hold
+// it: after the caller releases its own reference the worklet has to still be
+// there for the IPC to tear down against.
+//
+// This file is manual reference counting, so the retain the IPC takes is
+// observable directly.
+
+int
+main() {
+  BareWorklet *worklet = [[BareWorklet alloc] initWithConfiguration:nil];
+
+  NSString *source = @"BareKit.IPC.write('Hello!')";
+
+  [worklet start:@"/app.js" source:[source dataUsingEncoding:NSUTF8StringEncoding] arguments:@[]];
+
+  NSUInteger before = [worklet retainCount];
+
+  BareIPC *ipc = [[BareIPC alloc] initWithWorklet:worklet];
+
+  assert([worklet retainCount] == before + 1);
+
+  // The caller is done with it; the IPC's reference is what keeps it alive.
+  [worklet release];
+
+  [ipc close];
+  [ipc release];
+
+  return 0;
+}


### PR DESCRIPTION
Both bindings take a worklet in the constructor, reach into it, and drop the reference. So a BareIPC or a Java IPC can outlive the worklet it was opened on, with ARC or the collector picking the order.

Twelve lines to hold it in each, which makes the object graph say what is already true: an IPC without its worklet is meaningless.

Harmless on its own today. It becomes load-bearing with #106, where the queue belongs to the worklet and the host must retire its ipc first. Split out of #94.