### PR TITLE
Audit the workflows on every change

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -9,6 +9,11 @@ on:
 permissions:
   contents: read
 jobs:
+  security:
+    runs-on: ubuntu-latest
+    name: Security
+    steps:
+      - uses: holepunchto/actions/security-base@v1
   lint:
     runs-on: ubuntu-latest
     name: Lint


### PR DESCRIPTION
Rolls out the `security` step from holepunchto/actions, which runs zizmor over the workflows.

It caught two real problems in bare-collabora: `id-token: write` and `contents: write` declared at workflow level, so every build job inherited OIDC minting outside the npm environment gate. Both fixed there.

If this arrives red, the findings are the point - a fix PR lands ahead of it rather than anything being suppressed.
