### PR TITLE
Harden the publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
     tags:
       - v*
 permissions:
-  contents: write
+  contents: read
 jobs:
   apple:
     strategy:
@@ -193,6 +193,8 @@ jobs:
             prebuilds/win32/arm64/bare-kit.def
           retention-days: 5
   publish:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     needs: merge
     name: Publish
@@ -202,6 +204,7 @@ jobs:
         with:
           name: prebuilds
           skip-decompress: true
-      - run: gh release create ${{ github.ref_name }} prebuilds.zip --generate-notes
+      - run: gh release create "$TAG" prebuilds.zip --generate-notes
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}


### PR DESCRIPTION
Two findings from zizmor, both in `publish.yml`, blocking the audit job in #109.

`contents: write` was declared at workflow level, so the apple, android, linux, windows and merge jobs inherited it. They build from source and only move artifacts around; the `publish` job is the one that creates the release, so it gets the grant instead.

`gh release create ${{ github.ref_name }}` expanded the ref straight into the shell. It now arrives through the environment and is quoted, alongside the `GH_TOKEN` already there.

Same two fixes landed in bare-collabora as holepunchto/bare-collabora#60 and #61.

Zizmor still reports unpinned actions and cache-poisoning here; those are separate and follow.
