### PR TITLE
Publish without a restored package cache

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,6 +61,7 @@ jobs:
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 20
+          package-manager-cache: false
       - run: npm install --global bare-make
       - run: npm install
       - run: bare-make generate --platform ${{ matrix.platform }} --arch ${{ matrix.arch }} --with-debug-symbols ${{ matrix.flags }}
@@ -83,6 +84,7 @@ jobs:
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: lts/*
+          package-manager-cache: false
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: temurin
@@ -111,6 +113,7 @@ jobs:
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 20
+          package-manager-cache: false
       - run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
@@ -141,6 +144,7 @@ jobs:
       - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: 20
+          package-manager-cache: false
       - run: choco install llvm --version 20.1.8 --force
       - run: choco install nasm
       - run: npm install --global bare-make


### PR DESCRIPTION
Replaces #112, which closed itself when its base branch was deleted on merging #111. Same commit, rebased onto main - I should have retargeted it before merging, not after.

`setup-node` v6 turns on package-manager caching by default, so the release build restored a cache that jobs on other refs can populate. In a workflow that publishes, that is a path from a poisoned cache into what we ship, which is why zizmor reports it here and not in `integrate.yml`.

`package-manager-cache: false` on the four `setup-node` steps in `publish.yml` is the documented way off. It costs a clean install per job, on a workflow that runs once per release.

Last of the findings behind #109: with this, zizmor reports nothing on the version CI pins.
