### PR TITLE
Set up node through the shared action in the build jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,9 +58,9 @@ jobs:
     name: Build / ${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.tags }}
     steps:
       - uses: holepunchto/actions/checkout@v1
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+      - uses: holepunchto/actions/setup-node@v1
         with:
-          node-version: 20
+          version: 20
       - run: npm install --global bare-make
       - run: npm install
       - run: bare-make generate --platform ${{ matrix.platform }} --arch ${{ matrix.arch }} --with-debug-symbols ${{ matrix.flags }}
@@ -80,9 +80,7 @@ jobs:
     name: Build / ${{ matrix.platform }}
     steps:
       - uses: holepunchto/actions/checkout@v1
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
-        with:
-          node-version: lts/*
+      - uses: holepunchto/actions/setup-node@v1
       - uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: temurin
@@ -108,9 +106,9 @@ jobs:
     name: Build / ${{ matrix.platform }}-${{ matrix.arch }}
     steps:
       - uses: holepunchto/actions/checkout@v1
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+      - uses: holepunchto/actions/setup-node@v1
         with:
-          node-version: 20
+          version: 20
       - run: |
           wget https://apt.llvm.org/llvm.sh
           chmod +x llvm.sh
@@ -138,9 +136,9 @@ jobs:
     name: Build / ${{ matrix.platform }}-${{ matrix.arch }}
     steps:
       - uses: holepunchto/actions/checkout@v1
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+      - uses: holepunchto/actions/setup-node@v1
         with:
-          node-version: 20
+          version: 20
       - run: choco install llvm --version 20.1.8 --force
       - run: choco install nasm
       - run: npm install --global bare-make


### PR DESCRIPTION
The four `Build /` jobs in `publish.yml` call `actions/setup-node` directly, which zizmor reports as cache poisoning:

```
error[cache-poisoning]: runtime artifacts potentially vulnerable to a cache poisoning attack
  --> publish.yml:61  :83  :111  :141
```

`setup-node` enables caching by default, and this workflow runs on `push: tags` - it publishes artifacts built at runtime. #111 pinned these to a SHA, which is a different finding and does not affect this one.

`holepunchto/actions/setup-node` wraps the same action with its own pin. The explicit `lts/*` on the android job goes with the swap, since that is already the shared action's default; the three jobs on node 20 keep it as `version`.

These are the last 4 findings here. Same change as holepunchto/simdle-native#7. Clears what is blocking #109.
